### PR TITLE
fix: resolve native Claude binary and improve agent reliability

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "devloop",
       "dependencies": {
-        "@anthropic-ai/claude-code": "^1",
+        "@anthropic-ai/claude-code": "^1.0.128",
         "commander": "^12",
         "execa": "^9",
         "zod": "^3.24",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
-    "@anthropic-ai/claude-code": "^1",
+    "@anthropic-ai/claude-code": "^1.0.128",
     "commander": "^12",
     "execa": "^9",
     "zod": "^3.24"

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -61,8 +61,9 @@ export function createGitHubAdapter(repo: string): GitHubAdapter {
         "--base",
         opts.base,
       ]);
-      const raw = JSON.parse(stdout);
-      return raw.number;
+      const match = stdout.trim().match(/\/pull\/(\d+)$/);
+      if (!match) throw new Error(`unexpected gh pr create output: ${stdout}`);
+      return Number(match[1]);
     },
 
     async getCiStatus(branch) {
@@ -70,15 +71,14 @@ export function createGitHubAdapter(repo: string): GitHubAdapter {
         "api",
         `repos/${repo}/commits/${branch}/check-runs`,
         "--jq",
-        ".check_runs | map({state: .status, conclusion: .conclusion})",
+        ".check_runs | map({status: .status, conclusion: .conclusion})",
       ]);
-      const checks: Array<{ state: string; conclusion: string }> =
+      const checks: Array<{ status: string; conclusion: string | null }> =
         JSON.parse(stdout);
 
-      if (checks.length === 0) return "passing";
+      if (checks.length === 0) return "pending";
       if (checks.some((c) => c.conclusion === "failure")) return "failing";
-      if (checks.some((c) => c.state === "PENDING" || c.conclusion === ""))
-        return "pending";
+      if (checks.some((c) => c.status !== "completed")) return "pending";
       return "passing";
     },
 

--- a/src/agents/fixer.ts
+++ b/src/agents/fixer.ts
@@ -1,6 +1,6 @@
 import { query } from "@anthropic-ai/claude-code";
 import { FixSchema, type Fix, type Plan } from "../types.js";
-import { createSafetyHook } from "./shared.js";
+import { createSafetyHook, extractJson, getBaseSdkOptions } from "./shared.js";
 import type { Logger } from "../util/logger.js";
 
 export interface FixerInput {
@@ -42,6 +42,7 @@ Output ONLY valid JSON, no markdown fences.`;
   const response = query({
     prompt,
     options: {
+      ...getBaseSdkOptions(),
       cwd: input.cwd,
       permissionMode: "bypassPermissions",
       hooks: { PreToolUse: [createSafetyHook()] },
@@ -56,6 +57,6 @@ Output ONLY valid JSON, no markdown fences.`;
     }
   }
 
-  const parsed = JSON.parse(resultText);
+  const parsed = extractJson(resultText, "Fixer");
   return FixSchema.parse(parsed);
 }

--- a/src/agents/implementer.ts
+++ b/src/agents/implementer.ts
@@ -1,6 +1,6 @@
 import { query } from "@anthropic-ai/claude-code";
 import { ResultSchema, type Plan, type Result } from "../types.js";
-import { createSafetyHook } from "./shared.js";
+import { createSafetyHook, extractJson, getBaseSdkOptions } from "./shared.js";
 import type { Logger } from "../util/logger.js";
 
 export interface ImplementerInput {
@@ -39,6 +39,7 @@ Output ONLY valid JSON, no markdown fences.`;
   const response = query({
     prompt,
     options: {
+      ...getBaseSdkOptions(),
       cwd: input.cwd,
       permissionMode: "bypassPermissions",
       hooks: { PreToolUse: [createSafetyHook()] },
@@ -53,6 +54,6 @@ Output ONLY valid JSON, no markdown fences.`;
     }
   }
 
-  const parsed = JSON.parse(resultText);
+  const parsed = extractJson(resultText, "Implementer");
   return ResultSchema.parse(parsed);
 }

--- a/src/agents/planner.ts
+++ b/src/agents/planner.ts
@@ -1,6 +1,6 @@
 import { query, type SDKMessage } from "@anthropic-ai/claude-code";
 import { PlanSchema, type Plan } from "../types.js";
-import { createSafetyHook } from "./shared.js";
+import { createSafetyHook, extractJson, getBaseSdkOptions } from "./shared.js";
 import type { Issue } from "../adapters/github.js";
 import type { Logger } from "../util/logger.js";
 
@@ -13,31 +13,27 @@ export async function runPlanner(
   input: PlannerInput,
   logger: Logger
 ): Promise<Plan> {
-  const prompt = `You are a planning agent. Analyze the following GitHub issue and create an implementation plan.
+  const prompt = `Analyze the codebase and the following GitHub issue. Then output your implementation plan as a single JSON object.
 
 Issue #${input.issue.number}: ${input.issue.title}
 
 ${input.issue.body}
 
-Respond ONLY with a JSON object matching this schema:
-{
-  "summary": "string - brief summary of what needs to be done",
-  "steps": ["string[] - ordered implementation steps (at least 1)"],
-  "filesToTouch": ["string[] - files that will be created or modified"],
-  "tests": ["string[] - test files to create or modify"],
-  "risks": ["string[] - potential risks or concerns"],
-  "acceptanceCriteria": ["string[] - criteria for completion"]
-}
+IMPORTANT: First, explore the codebase to understand the structure. Then output ONLY a JSON object (no prose, no markdown fences, no explanation before or after).
 
-Output ONLY valid JSON, no markdown fences, no explanation.`;
+Required JSON schema:
+{"summary":"string","steps":["string"],"filesToTouch":["string"],"tests":["string"],"risks":["string"],"acceptanceCriteria":["string"]}
+
+Your final message must contain ONLY the JSON object, nothing else.`;
 
   logger.info("Running planner agent", { issue: input.issue.number });
 
   const response = query({
     prompt,
     options: {
+      ...getBaseSdkOptions(),
       cwd: input.cwd,
-      permissionMode: "plan",
+      permissionMode: "bypassPermissions",
       allowedTools: ["Read", "Glob", "Grep", "Bash"],
       hooks: { PreToolUse: [createSafetyHook()] },
       maxTurns: 20,
@@ -51,6 +47,8 @@ Output ONLY valid JSON, no markdown fences, no explanation.`;
     }
   }
 
-  const parsed = JSON.parse(resultText);
+  logger.info("Planner response", { length: resultText.length });
+
+  const parsed = extractJson(resultText, "Planner");
   return PlanSchema.parse(parsed);
 }

--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -1,6 +1,6 @@
 import { query } from "@anthropic-ai/claude-code";
 import { ReviewSchema, type Plan, type Review } from "../types.js";
-import { createSafetyHook } from "./shared.js";
+import { createSafetyHook, extractJson, getBaseSdkOptions } from "./shared.js";
 import type { Logger } from "../util/logger.js";
 
 export interface ReviewerInput {
@@ -43,8 +43,9 @@ Output ONLY valid JSON, no markdown fences.`;
   const response = query({
     prompt,
     options: {
+      ...getBaseSdkOptions(),
       cwd: input.cwd,
-      permissionMode: "plan",
+      permissionMode: "bypassPermissions",
       allowedTools: ["Read", "Glob", "Grep", "Bash"],
       hooks: { PreToolUse: [createSafetyHook()] },
       maxTurns: 20,
@@ -58,6 +59,6 @@ Output ONLY valid JSON, no markdown fences.`;
     }
   }
 
-  const parsed = JSON.parse(resultText);
+  const parsed = extractJson(resultText, "Reviewer");
   return ReviewSchema.parse(parsed);
 }

--- a/src/agents/shared.ts
+++ b/src/agents/shared.ts
@@ -1,6 +1,9 @@
+import { accessSync, constants } from "node:fs";
+import { join } from "node:path";
 import type {
   HookCallback,
   HookCallbackMatcher,
+  Options,
   SyncHookJSONOutput,
 } from "@anthropic-ai/claude-code";
 
@@ -55,4 +58,59 @@ export function createSafetyHook(): HookCallbackMatcher {
     );
   };
   return { hooks: [hook] };
+}
+
+/** 入れ子判定を回避するために削除する環境変数 */
+const NESTED_DETECTION_VARS = ["CLAUDECODE"];
+
+export function cleanEnvForSdk(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined) continue;
+    if (NESTED_DETECTION_VARS.includes(key)) continue;
+    env[key] = value;
+  }
+  // SDK として起動することを明示
+  env.CLAUDE_CODE_ENTRYPOINT = "sdk-ts";
+  return env;
+}
+
+export function findClaudeExecutable(): string | undefined {
+  if (process.env.CLAUDE_EXECUTABLE) return process.env.CLAUDE_EXECUTABLE;
+
+  const pathDirs = (process.env.PATH ?? "").split(":");
+  for (const dir of pathDirs) {
+    if (dir.includes("node_modules")) continue;
+    const candidate = join(dir, "claude");
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+export function extractJson(text: string, agentName: string): unknown {
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) {
+    throw new Error(`${agentName} did not return JSON. Response: ${text.slice(0, 500)}`);
+  }
+  return JSON.parse(match[0]);
+}
+
+export function getBaseSdkOptions(): Pick<Options, "pathToClaudeCodeExecutable" | "env"> {
+  const executable = findClaudeExecutable();
+  if (!executable) {
+    throw new Error(
+      "Native Claude Code binary not found. " +
+      "Install: https://docs.anthropic.com/en/docs/claude-code or " +
+      "set --claude-path / CLAUDE_EXECUTABLE"
+    );
+  }
+  return {
+    pathToClaudeCodeExecutable: executable,
+    env: cleanEnvForSdk(),
+  };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,7 +70,9 @@ export function createCli() {
     .option("--dry-run", "Skip push/PR/merge", false)
     .option("--no-merge", "Skip merge after CI passes")
     .option("--repo <owner/name>", "GitHub repo (owner/name)")
+    .option("--claude-path <path>", "Path to native Claude Code executable")
     .action(async (opts) => {
+      if (opts.claudePath) process.env.CLAUDE_EXECUTABLE = opts.claudePath;
       const logger = createLogger("info");
       const runId = `run-${Date.now()}-${randomUUID().slice(0, 8)}`;
       const cwd = opts.cwd;
@@ -122,7 +124,9 @@ export function createCli() {
     .option("--interval <seconds>", "Poll interval in seconds", parseInt, 30)
     .option("--cwd <path>", "Working directory", process.cwd())
     .option("--repo <owner/name>", "GitHub repo (owner/name)")
+    .option("--claude-path <path>", "Path to native Claude Code executable")
     .action(async (opts) => {
+      if (opts.claudePath) process.env.CLAUDE_EXECUTABLE = opts.claudePath;
       const logger = createLogger("info");
       const repo = opts.repo ?? detectRepo(opts.cwd);
       const github = createGitHubAdapter(repo);

--- a/test/adapters/github.test.ts
+++ b/test/adapters/github.test.ts
@@ -51,9 +51,9 @@ describe("GitHubAdapter", () => {
   });
 
   describe("createPr", () => {
-    it("creates PR and returns number", async () => {
+    it("creates PR and returns number parsed from URL", async () => {
       mockExeca.mockResolvedValue({
-        stdout: JSON.stringify({ number: 10, url: "https://github.com/..." }),
+        stdout: "https://github.com/mizumura3/inko/pull/10\n",
       } as any);
 
       const prNumber = await gh.createPr({
@@ -85,7 +85,7 @@ describe("GitHubAdapter", () => {
     it("returns passing when all checks pass", async () => {
       mockExeca.mockResolvedValue({
         stdout: JSON.stringify([
-          { state: "SUCCESS", conclusion: "success" },
+          { status: "completed", conclusion: "success" },
         ]),
       } as any);
 
@@ -96,7 +96,7 @@ describe("GitHubAdapter", () => {
     it("returns failing when a check fails", async () => {
       mockExeca.mockResolvedValue({
         stdout: JSON.stringify([
-          { state: "FAILURE", conclusion: "failure" },
+          { status: "completed", conclusion: "failure" },
         ]),
       } as any);
 
@@ -107,7 +107,7 @@ describe("GitHubAdapter", () => {
     it("returns pending when checks are in progress", async () => {
       mockExeca.mockResolvedValue({
         stdout: JSON.stringify([
-          { state: "PENDING", conclusion: "" },
+          { status: "in_progress", conclusion: null },
         ]),
       } as any);
 
@@ -115,10 +115,10 @@ describe("GitHubAdapter", () => {
       expect(status).toBe("pending");
     });
 
-    it("returns passing when no checks", async () => {
+    it("returns pending when no checks exist (push race condition)", async () => {
       mockExeca.mockResolvedValue({ stdout: "[]" } as any);
       const status = await gh.getCiStatus("feature/x");
-      expect(status).toBe("passing");
+      expect(status).toBe("pending");
     });
   });
 

--- a/test/agents/shared.test.ts
+++ b/test/agents/shared.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { blockDangerousOps } from "../../src/agents/shared.js";
+import { describe, it, expect, vi } from "vitest";
+import { blockDangerousOps, cleanEnvForSdk, extractJson, getBaseSdkOptions, findClaudeExecutable } from "../../src/agents/shared.js";
 
 describe("blockDangerousOps", () => {
   describe("Bash tool", () => {
@@ -109,5 +109,163 @@ describe("blockDangerousOps", () => {
       const result = await blockDangerousOps("Glob", { pattern: "**/*.ts" });
       expect(result.decision).toBeUndefined();
     });
+  });
+});
+
+describe("cleanEnvForSdk", () => {
+  function withEnv(vars: Record<string, string>, fn: () => void) {
+    const originals: Record<string, string | undefined> = {};
+    for (const key of Object.keys(vars)) {
+      originals[key] = process.env[key];
+      process.env[key] = vars[key];
+    }
+    try {
+      fn();
+    } finally {
+      for (const [key, orig] of Object.entries(originals)) {
+        if (orig === undefined) delete process.env[key];
+        else process.env[key] = orig;
+      }
+    }
+  }
+
+  it("removes CLAUDECODE marker", () => {
+    withEnv({ CLAUDECODE: "1" }, () => {
+      const env = cleanEnvForSdk();
+      expect(env.CLAUDECODE).toBeUndefined();
+    });
+  });
+
+  it("overrides CLAUDE_CODE_ENTRYPOINT to sdk-ts", () => {
+    withEnv({ CLAUDE_CODE_ENTRYPOINT: "cli" }, () => {
+      const env = cleanEnvForSdk();
+      expect(env.CLAUDE_CODE_ENTRYPOINT).toBe("sdk-ts");
+    });
+  });
+
+  it("preserves other CLAUDE_CODE_ prefixed vars (feature flags etc)", () => {
+    withEnv({ CLAUDE_CODE_SOME_FEATURE: "enabled" }, () => {
+      const env = cleanEnvForSdk();
+      expect(env.CLAUDE_CODE_SOME_FEATURE).toBe("enabled");
+    });
+  });
+
+  it("preserves ANTHROPIC_API_KEY", () => {
+    withEnv({ ANTHROPIC_API_KEY: "sk-test-key" }, () => {
+      const env = cleanEnvForSdk();
+      expect(env.ANTHROPIC_API_KEY).toBe("sk-test-key");
+    });
+  });
+
+  it("preserves non-CLAUDE env vars (HOME, PATH etc)", () => {
+    const env = cleanEnvForSdk();
+    expect(env.HOME).toBe(process.env.HOME);
+    expect(env.PATH).toBe(process.env.PATH);
+  });
+});
+
+describe("findClaudeExecutable", () => {
+  function withEnv(vars: Record<string, string | undefined>, fn: () => void) {
+    const originals: Record<string, string | undefined> = {};
+    for (const key of Object.keys(vars)) {
+      originals[key] = process.env[key];
+      if (vars[key] === undefined) delete process.env[key];
+      else process.env[key] = vars[key];
+    }
+    try {
+      fn();
+    } finally {
+      for (const [key, orig] of Object.entries(originals)) {
+        if (orig === undefined) delete process.env[key];
+        else process.env[key] = orig;
+      }
+    }
+  }
+
+  it("uses CLAUDE_EXECUTABLE env var when set", () => {
+    withEnv({ CLAUDE_EXECUTABLE: "/custom/path/to/claude" }, () => {
+      expect(findClaudeExecutable()).toBe("/custom/path/to/claude");
+    });
+  });
+
+  it("skips node_modules/.bin entries from PATH", () => {
+    withEnv({
+      CLAUDE_EXECUTABLE: undefined,
+      PATH: "/project/node_modules/.bin:/usr/local/bin",
+    }, () => {
+      // node_modules/.bin/claude should be skipped even if it exists
+      // The function should not return a path containing node_modules
+      const result = findClaudeExecutable();
+      if (result) {
+        expect(result).not.toContain("node_modules");
+      }
+    });
+  });
+
+  it("returns native binary path when found in PATH", () => {
+    // Use the real PATH but without CLAUDE_EXECUTABLE override
+    withEnv({ CLAUDE_EXECUTABLE: undefined }, () => {
+      const result = findClaudeExecutable();
+      // In CI or environments without claude installed, may be undefined
+      if (result) {
+        expect(result).toContain("claude");
+        expect(result).not.toContain("node_modules");
+      }
+    });
+  });
+
+  it("returns undefined when no native binary found", () => {
+    withEnv({
+      CLAUDE_EXECUTABLE: undefined,
+      PATH: "/nonexistent/dir:/another/nonexistent",
+    }, () => {
+      expect(findClaudeExecutable()).toBeUndefined();
+    });
+  });
+});
+
+describe("extractJson", () => {
+  it("extracts JSON from pure JSON text", () => {
+    const text = '{"summary":"test","steps":["step1"]}';
+    const result = extractJson(text, "Test") as any;
+    expect(result.summary).toBe("test");
+  });
+
+  it("extracts JSON embedded in prose", () => {
+    const text = 'Here is the plan:\n{"summary":"test","steps":["step1"]}\nDone.';
+    const result = extractJson(text, "Test") as any;
+    expect(result.summary).toBe("test");
+  });
+
+  it("throws when no JSON found", () => {
+    expect(() => extractJson("No JSON here", "Test")).toThrow("Test did not return JSON");
+  });
+});
+
+describe("getBaseSdkOptions", () => {
+  it("uses CLAUDE_EXECUTABLE env var when set", () => {
+    const original = process.env.CLAUDE_EXECUTABLE;
+    process.env.CLAUDE_EXECUTABLE = "/custom/path/to/claude";
+    try {
+      const opts = getBaseSdkOptions();
+      expect(opts.pathToClaudeCodeExecutable).toBe("/custom/path/to/claude");
+    } finally {
+      if (original === undefined) delete process.env.CLAUDE_EXECUTABLE;
+      else process.env.CLAUDE_EXECUTABLE = original;
+    }
+  });
+
+  it("throws when no native binary found", () => {
+    const origExe = process.env.CLAUDE_EXECUTABLE;
+    const origPath = process.env.PATH;
+    delete process.env.CLAUDE_EXECUTABLE;
+    process.env.PATH = "/nonexistent/dir";
+    try {
+      expect(() => getBaseSdkOptions()).toThrow("Native Claude Code binary not found");
+    } finally {
+      if (origExe !== undefined) process.env.CLAUDE_EXECUTABLE = origExe;
+      else delete process.env.CLAUDE_EXECUTABLE;
+      process.env.PATH = origPath;
+    }
   });
 });


### PR DESCRIPTION
## Summary

- **findClaudeExecutable 改修**: `which claude` の代わりに PATH を自前走査し、`node_modules/.bin` を除外してネイティブバイナリを確実に解決。`bun run` 経由でも SDK の cli.js（Node v25 でクラッシュ）を回避できる
- **Agent の permissionMode 修正**: `plan` → `bypassPermissions` に変更。plan mode では JSON レスポンスが空/プロステキストになる問題を解消
- **extractJson ヘルパー追加**: モデルがプロステキスト混じりで返した場合でも JSON を抽出できるガードを全 agent に適用
- **GitHub adapter バグ修正**: `gh pr create` の URL パース、CI check のフィールド名修正、空チェック時の pending 扱い
- **CLI に `--claude-path` オプション追加**: ネイティブバイナリの明示指定をサポート

## Test plan

- [x] `findClaudeExecutable` テスト（env var / node_modules 除外 / PATH 走査 / not found）
- [x] `extractJson` テスト（純 JSON / プロステキスト混在 / JSON なし）
- [x] `getBaseSdkOptions` テスト（正常 / バイナリ未検出エラー）
- [x] `cleanEnvForSdk` テスト（CLAUDECODE 除外 / ENTRYPOINT 上書き / 他変数保持）
- [x] inko#2 で dry-run 実行: planning → implementing → reviewing → committing → done 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)