### PR TITLE
feat: pass actual CI logs to fixer agent

### DIFF
--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -24,6 +24,7 @@ export interface GitHubAdapter {
   mergePr(number: number): Promise<void>;
   closeIssue(number: number): Promise<void>;
   listIssuesByLabel(label: string): Promise<Issue[]>;
+  getCheckRunLogs(branch: string): Promise<string>;
 }
 
 export function createGitHubAdapter(repo: string): GitHubAdapter {
@@ -115,6 +116,40 @@ export function createGitHubAdapter(repo: string): GitHubAdapter {
         "--repo",
         repo,
       ]);
+    },
+
+    async getCheckRunLogs(branch) {
+      const { stdout: listOut } = await execa("gh", [
+        "run",
+        "list",
+        "--repo",
+        repo,
+        "--branch",
+        branch,
+        "--status",
+        "failure",
+        "--limit",
+        "1",
+        "--json",
+        "databaseId",
+      ]);
+      const runs: Array<{ databaseId: number }> = JSON.parse(listOut);
+      if (runs.length === 0) return "No failed CI runs found";
+
+      const { stdout: logOut } = await execa("gh", [
+        "run",
+        "view",
+        String(runs[0]!.databaseId),
+        "--repo",
+        repo,
+        "--log-failed",
+      ]);
+
+      const lines = logOut.split("\n");
+      if (lines.length > 200) {
+        return lines.slice(-200).join("\n");
+      }
+      return logOut;
     },
 
     async listIssuesByLabel(label) {

--- a/src/workflow/states.ts
+++ b/src/workflow/states.ts
@@ -142,8 +142,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
 
   const fixing: StateHandler = async (ctx) => {
     if (!ctx.plan) throw new Error("No plan available");
-    // TODO: get actual CI logs via gh api
-    const ciLog = "CI failure - see logs for details";
+    const ciLog = await github.getCheckRunLogs(ctx.branch);
     const fixStart = performance.now();
     const fix = await runFixer(
       { plan: ctx.plan, ciLog, cwd: ctx.cwd },

--- a/test/adapters/github.test.ts
+++ b/test/adapters/github.test.ts
@@ -166,6 +166,73 @@ describe("GitHubAdapter", () => {
     });
   });
 
+  describe("getCheckRunLogs", () => {
+    it("returns logs from the latest failed run", async () => {
+      // First call: gh run list → returns a failed run
+      mockExeca.mockResolvedValueOnce({
+        stdout: JSON.stringify([{ databaseId: 12345 }]),
+      } as any);
+      // Second call: gh run view --log-failed → returns log output
+      mockExeca.mockResolvedValueOnce({
+        stdout: "Error: test failed\n  at src/index.ts:10\n",
+      } as any);
+
+      const logs = await gh.getCheckRunLogs("feature/x");
+
+      expect(mockExeca).toHaveBeenCalledWith("gh", [
+        "run",
+        "list",
+        "--repo",
+        repo,
+        "--branch",
+        "feature/x",
+        "--status",
+        "failure",
+        "--limit",
+        "1",
+        "--json",
+        "databaseId",
+      ]);
+      expect(mockExeca).toHaveBeenCalledWith("gh", [
+        "run",
+        "view",
+        "12345",
+        "--repo",
+        repo,
+        "--log-failed",
+      ]);
+      expect(logs).toBe("Error: test failed\n  at src/index.ts:10\n");
+    });
+
+    it("returns fallback message when no failed runs exist", async () => {
+      mockExeca.mockResolvedValueOnce({
+        stdout: JSON.stringify([]),
+      } as any);
+
+      const logs = await gh.getCheckRunLogs("feature/x");
+
+      expect(logs).toBe("No failed CI runs found");
+      expect(mockExeca).toHaveBeenCalledTimes(1);
+    });
+
+    it("truncates logs to the last 200 lines", async () => {
+      mockExeca.mockResolvedValueOnce({
+        stdout: JSON.stringify([{ databaseId: 99 }]),
+      } as any);
+      const longLog = Array.from({ length: 300 }, (_, i) => `line ${i + 1}`).join("\n");
+      mockExeca.mockResolvedValueOnce({
+        stdout: longLog,
+      } as any);
+
+      const logs = await gh.getCheckRunLogs("feature/x");
+
+      const lines = logs.split("\n");
+      expect(lines).toHaveLength(200);
+      expect(lines[0]).toBe("line 101");
+      expect(lines[199]).toBe("line 300");
+    });
+  });
+
   describe("listIssuesByLabel", () => {
     it("returns issues with label", async () => {
       mockExeca.mockResolvedValue({


### PR DESCRIPTION
## Summary
- `GitHubAdapter` に `getCheckRunLogs(branch)` を追加。`gh run list --status failure` → `gh run view --log-failed` で実際の CI ログを取得
- `fixing` ハンドラのダミーログ `"CI failure - see logs for details"` を実ログに置換
- ログが 200 行を超える場合は末尾 200 行に truncate

## Test plan
- [x] `getCheckRunLogs` - 失敗 run がある場合、ログを返す
- [x] `getCheckRunLogs` - 失敗 run がない場合、フォールバックメッセージを返す
- [x] `getCheckRunLogs` - 300 行ログが末尾 200 行に truncate される
- [x] 既存テスト 79 件すべて GREEN
- [x] `tsc --noEmit` パス

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)