### PR TITLE
feat: replace noMerge with autoMerge flag

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,7 +89,7 @@ export function createCli() {
     .option("--cwd <path>", "Working directory", process.cwd())
     .option("--max-fix-attempts <n>", "Max CI fix attempts", parseInt, 3)
     .option("--dry-run", "Skip push/PR/merge", false)
-    .option("--no-merge", "Skip merge after CI passes")
+    .option("--auto-merge", "Merge PR and close issue after CI passes", false)
     .option("--repo <owner/name>", "GitHub repo (owner/name)")
     .option("--claude-path <path>", "Path to native Claude Code executable")
     .option("--resume", "Resume the latest run for this issue")
@@ -115,7 +115,7 @@ export function createCli() {
         ctx = {
           ...saved,
           dryRun: opts.dryRun,
-          noMerge: !opts.merge,
+          autoMerge: opts.autoMerge,
         };
         // If previous run completed as done (dry-run), restart from creating_pr
         // (commit already exists, just need push + PR)
@@ -139,7 +139,7 @@ export function createCli() {
           maxFixAttempts: opts.maxFixAttempts,
           fixAttempts: 0,
           dryRun: opts.dryRun,
-          noMerge: !opts.merge,
+          autoMerge: opts.autoMerge,
         };
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,7 +60,7 @@ export const RunContextSchema = z.object({
   maxFixAttempts: z.number().default(3),
   fixAttempts: z.number().default(0),
   dryRun: z.boolean(),
-  noMerge: z.boolean(),
+  autoMerge: z.boolean().default(false),
   plan: PlanSchema.optional(),
   result: ResultSchema.optional(),
   review: ReviewSchema.optional(),

--- a/src/workflow/states.ts
+++ b/src/workflow/states.ts
@@ -120,7 +120,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
       const status = await github.getCiStatus(ctx.branch);
       if (status === "passing") {
         logger.info("CI passed");
-        if (ctx.noMerge) return transition(ctx, "done");
+        if (!ctx.autoMerge) return transition(ctx, "done");
         return transition(ctx, "merging");
       }
       if (status === "failing") {

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -151,7 +151,7 @@ describe("RunContextSchema", () => {
     maxFixAttempts: 3,
     fixAttempts: 0,
     dryRun: false,
-    noMerge: false,
+    autoMerge: false,
   };
 
   it("accepts valid context", () => {
@@ -184,6 +184,12 @@ describe("RunContextSchema", () => {
     const { fixAttempts, ...rest } = validContext;
     const parsed = RunContextSchema.parse(rest);
     expect(parsed.fixAttempts).toBe(0);
+  });
+
+  it("defaults autoMerge to false", () => {
+    const { autoMerge, ...rest } = validContext;
+    const parsed = RunContextSchema.parse(rest);
+    expect(parsed.autoMerge).toBe(false);
   });
 
   it("rejects context without issueNumber", () => {

--- a/test/workflow/engine.test.ts
+++ b/test/workflow/engine.test.ts
@@ -18,7 +18,7 @@ function makeCtx(overrides: Partial<RunContext> = {}): RunContext {
     maxFixAttempts: 3,
     fixAttempts: 0,
     dryRun: false,
-    noMerge: false,
+    autoMerge: false,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- `noMerge: boolean` → `autoMerge: boolean` (default `false`) にリネーム + セマンティクス反転
- デフォルトでマージしない動作に変更（`--auto-merge` 明示指定時のみマージ）
- 否定形 boolean (`noMerge`) を肯定形 (`autoMerge`) に統一して可読性向上

## Changes
- **`src/types.ts`**: `noMerge: z.boolean()` → `autoMerge: z.boolean().default(false)`
- **`src/workflow/states.ts`**: `if (ctx.noMerge)` → `if (!ctx.autoMerge)`
- **`src/cli.ts`**: `--no-merge` → `--auto-merge` (default: false)
- **`test/types.test.ts`**: テスト更新 + `defaults autoMerge to false` テスト追加
- **`test/workflow/engine.test.ts`**: `makeCtx` 更新

## Test plan
- [x] `bun test` で全テスト pass (77 pass, 0 fail)
- [x] `bun run build` (tsc) でコンパイルエラーなし
- [ ] `--auto-merge` なしで実行 → PR 作成後マージされないことを確認
- [ ] `--auto-merge` ありで実行 → CI pass 後にマージされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)