### PR TITLE
feat: add label-based auto-merge decision

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -140,6 +140,7 @@ export function createCli() {
           fixAttempts: 0,
           dryRun: opts.dryRun,
           autoMerge: opts.autoMerge,
+          issueLabels: [],
         };
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export const RunContextSchema = z.object({
   fixAttempts: z.number().default(0),
   dryRun: z.boolean(),
   autoMerge: z.boolean().default(false),
+  issueLabels: z.array(z.string()).default([]),
   plan: PlanSchema.optional(),
   result: ResultSchema.optional(),
   review: ReviewSchema.optional(),

--- a/src/workflow/states.ts
+++ b/src/workflow/states.ts
@@ -22,6 +22,10 @@ function transition(
   return { nextState, ctx: { ...ctx, ...patch, state: nextState } };
 }
 
+function shouldAutoMerge(ctx: RunContext): boolean {
+  return ctx.autoMerge || ctx.issueLabels.includes("auto-merge");
+}
+
 export function createStateHandlers(deps: Deps): StateHandlerMap {
   const { git, github, logger } = deps;
 
@@ -33,7 +37,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
     });
     await git.createBranch(ctx.branch, ctx.cwd);
     logger.info("Created branch", { branch: ctx.branch });
-    return transition(ctx, "planning");
+    return transition(ctx, "planning", { issueLabels: issue.labels });
   };
 
   const planning: StateHandler = async (ctx) => {
@@ -120,7 +124,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
       const status = await github.getCiStatus(ctx.branch);
       if (status === "passing") {
         logger.info("CI passed");
-        if (!ctx.autoMerge) return transition(ctx, "done");
+        if (!shouldAutoMerge(ctx)) return transition(ctx, "done");
         return transition(ctx, "merging");
       }
       if (status === "failing") {

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -152,6 +152,7 @@ describe("RunContextSchema", () => {
     fixAttempts: 0,
     dryRun: false,
     autoMerge: false,
+    issueLabels: [],
   };
 
   it("accepts valid context", () => {
@@ -190,6 +191,19 @@ describe("RunContextSchema", () => {
     const { autoMerge, ...rest } = validContext;
     const parsed = RunContextSchema.parse(rest);
     expect(parsed.autoMerge).toBe(false);
+  });
+
+  it("defaults issueLabels to empty array", () => {
+    const parsed = RunContextSchema.parse(validContext);
+    expect(parsed.issueLabels).toEqual([]);
+  });
+
+  it("accepts issueLabels with string array", () => {
+    const parsed = RunContextSchema.parse({
+      ...validContext,
+      issueLabels: ["auto-merge", "bug"],
+    });
+    expect(parsed.issueLabels).toEqual(["auto-merge", "bug"]);
   });
 
   it("rejects context without issueNumber", () => {

--- a/test/workflow/engine.test.ts
+++ b/test/workflow/engine.test.ts
@@ -19,6 +19,7 @@ function makeCtx(overrides: Partial<RunContext> = {}): RunContext {
     fixAttempts: 0,
     dryRun: false,
     autoMerge: false,
+    issueLabels: [],
     ...overrides,
   };
 }

--- a/test/workflow/states.test.ts
+++ b/test/workflow/states.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from "vitest";
+import { createStateHandlers, type Deps } from "../../src/workflow/states.js";
+import type { RunContext } from "../../src/types.js";
+import type { GitAdapter } from "../../src/adapters/git.js";
+import type { GitHubAdapter } from "../../src/adapters/github.js";
+import type { Logger } from "../../src/util/logger.js";
+
+function makeCtx(overrides: Partial<RunContext> = {}): RunContext {
+  return {
+    runId: "test-run",
+    issueNumber: 1,
+    repo: "owner/repo",
+    cwd: "/tmp/repo",
+    state: "init",
+    branch: "devloop/issue-1",
+    maxFixAttempts: 3,
+    fixAttempts: 0,
+    dryRun: false,
+    autoMerge: false,
+    issueLabels: [],
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides?: {
+  git?: Partial<GitAdapter>;
+  github?: Partial<GitHubAdapter>;
+}): Deps {
+  const git: GitAdapter = {
+    createBranch: vi.fn(async () => {}),
+    addAll: vi.fn(async () => {}),
+    commit: vi.fn(async () => {}),
+    push: vi.fn(async () => {}),
+    diff: vi.fn(async () => ""),
+    currentBranch: vi.fn(async () => "main"),
+    ...overrides?.git,
+  };
+  const github: GitHubAdapter = {
+    getIssue: vi.fn(async () => ({
+      number: 1,
+      title: "Test issue",
+      body: "Test body",
+      labels: [],
+    })),
+    commentOnIssue: vi.fn(async () => {}),
+    createPr: vi.fn(async () => 42),
+    getCiStatus: vi.fn(async () => "passing" as const),
+    mergePr: vi.fn(async () => {}),
+    closeIssue: vi.fn(async () => {}),
+    listIssuesByLabel: vi.fn(async () => []),
+    getCheckRunLogs: vi.fn(async () => ""),
+    ...overrides?.github,
+  };
+  const logger: Logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  return { git, github, logger };
+}
+
+describe("init handler", () => {
+  it("saves issue labels to ctx.issueLabels", async () => {
+    const deps = makeDeps({
+      github: {
+        getIssue: vi.fn(async () => ({
+          number: 1,
+          title: "Test",
+          body: "",
+          labels: ["auto-merge", "enhancement"],
+        })),
+      },
+    });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx();
+
+    const result = await handlers.init!(ctx);
+
+    expect(result.ctx.issueLabels).toEqual(["auto-merge", "enhancement"]);
+    expect(result.nextState).toBe("planning");
+  });
+
+  it("saves empty labels when issue has none", async () => {
+    const deps = makeDeps();
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx();
+
+    const result = await handlers.init!(ctx);
+
+    expect(result.ctx.issueLabels).toEqual([]);
+  });
+});
+
+describe("watching_ci handler", () => {
+  it("transitions to merging when issueLabels includes auto-merge", async () => {
+    const deps = makeDeps();
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      state: "watching_ci",
+      prNumber: 42,
+      autoMerge: false,
+      issueLabels: ["auto-merge"],
+    });
+
+    const result = await handlers.watching_ci!(ctx);
+
+    expect(result.nextState).toBe("merging");
+  });
+
+  it("transitions to merging when autoMerge flag is true", async () => {
+    const deps = makeDeps();
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      state: "watching_ci",
+      prNumber: 42,
+      autoMerge: true,
+      issueLabels: [],
+    });
+
+    const result = await handlers.watching_ci!(ctx);
+
+    expect(result.nextState).toBe("merging");
+  });
+
+  it("transitions to done when no auto-merge label and autoMerge is false", async () => {
+    const deps = makeDeps();
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      state: "watching_ci",
+      prNumber: 42,
+      autoMerge: false,
+      issueLabels: ["bug"],
+    });
+
+    const result = await handlers.watching_ci!(ctx);
+
+    expect(result.nextState).toBe("done");
+  });
+});


### PR DESCRIPTION
## Summary

- Issue に `auto-merge` ラベルがあれば CI 通過後に自動マージする
- `issueLabels: string[]` を RunContext に追加し、`init` handler で Issue の labels を保存
- `watching_ci` handler で `shouldAutoMerge()` ヘルパーにより `autoMerge` フラグまたはラベルで判断

## Test plan

- [x] `issueLabels` スキーマテスト（デフォルト `[]`、配列受け入れ）
- [x] `init` handler が Issue labels を `ctx.issueLabels` に保存するテスト
- [x] `watching_ci` handler: `auto-merge` ラベルあり → `merging` 遷移
- [x] `watching_ci` handler: `autoMerge=true` → `merging` 遷移
- [x] `watching_ci` handler: ラベルなし＋フラグ false → `done` 遷移
- [x] 87 tests all GREEN, tsc build clean

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)