### PR TITLE
feat: add `aidev improve` command with detectors and deduplication (#12)

### DIFF
--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -16,6 +16,12 @@ export interface CreatePrOpts {
 
 export type CiStatus = "passing" | "failing" | "pending";
 
+export interface CreateIssueOpts {
+  title: string;
+  body: string;
+  labels: string[];
+}
+
 export interface GitHubAdapter {
   getIssue(number: number): Promise<Issue>;
   commentOnIssue(number: number, body: string): Promise<void>;
@@ -25,6 +31,8 @@ export interface GitHubAdapter {
   closeIssue(number: number): Promise<void>;
   listIssuesByLabel(label: string): Promise<Issue[]>;
   getCheckRunLogs(branch: string): Promise<string>;
+  createIssue(opts: CreateIssueOpts): Promise<number>;
+  searchIssues(query: string): Promise<Issue[]>;
 }
 
 export function createGitHubAdapter(repo: string): GitHubAdapter {
@@ -162,6 +170,53 @@ export function createGitHubAdapter(repo: string): GitHubAdapter {
         label,
         "--json",
         "number,title,body,labels",
+      ]);
+      const raw: Array<{
+        number: number;
+        title: string;
+        body: string;
+        labels: Array<{ name: string }>;
+      }> = JSON.parse(stdout);
+      return raw.map((r) => ({
+        number: r.number,
+        title: r.title,
+        body: r.body,
+        labels: r.labels.map((l) => l.name),
+      }));
+    },
+
+    async createIssue(opts) {
+      const args = [
+        "issue",
+        "create",
+        "--repo",
+        repo,
+        "--title",
+        opts.title,
+        "--body",
+        opts.body,
+      ];
+      for (const label of opts.labels) {
+        args.push("--label", label);
+      }
+      const { stdout } = await execa("gh", args);
+      const match = stdout.trim().match(/\/issues\/(\d+)$/);
+      if (!match) throw new Error(`unexpected gh issue create output: ${stdout}`);
+      return Number(match[1]);
+    },
+
+    async searchIssues(query) {
+      const { stdout } = await execa("gh", [
+        "search",
+        "issues",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--json",
+        "number,title,body,labels",
+        "--",
+        query,
       ]);
       const raw: Array<{
         number: number;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,11 @@ import { createGitHubAdapter } from "./adapters/github.js";
 import { createLogger } from "./util/logger.js";
 import { runWorkflow, type Persistence } from "./workflow/engine.js";
 import { createStateHandlers } from "./workflow/states.js";
+import { runImprove } from "./improve/runner.js";
+import { createTodoDetector } from "./improve/detectors/todo.js";
+import { createLintDetector } from "./improve/detectors/lint.js";
+import { createOutdatedDetector } from "./improve/detectors/outdated.js";
+import type { Detector } from "./improve/types.js";
 import type { RunContext } from "./types.js";
 
 function createFilePersistence(baseDir: string): Persistence {
@@ -235,6 +240,48 @@ export function createCli() {
         process.exit(1);
       }
       console.log(JSON.stringify(ctx, null, 2));
+    });
+
+  program
+    .command("improve")
+    .description("Scan repository for improvements and create GitHub Issues")
+    .requiredOption("--repo <owner/name>", "GitHub repo (owner/name)")
+    .option("--cwd <path>", "Working directory", process.cwd())
+    .option("--dry-run", "Print findings without creating issues", false)
+    .option("--watch", "Poll at regular intervals", false)
+    .option("--interval <minutes>", "Watch interval in minutes", parseInt, 60)
+    .option("--detectors <list>", "Comma-separated list of detectors (todo,lint,outdated)", "todo,lint,outdated")
+    .action(async (opts) => {
+      const logger = createLogger("info");
+      const github = createGitHubAdapter(opts.repo);
+
+      const detectorMap: Record<string, () => Detector> = {
+        todo: createTodoDetector,
+        lint: createLintDetector,
+        outdated: createOutdatedDetector,
+      };
+
+      const enabledNames = (opts.detectors as string).split(",").map((s: string) => s.trim());
+      const detectors = enabledNames
+        .filter((name: string) => detectorMap[name])
+        .map((name: string) => detectorMap[name]!());
+
+      const run = () =>
+        runImprove({
+          cwd: opts.cwd,
+          repo: opts.repo,
+          detectors,
+          github,
+          logger,
+          dryRun: opts.dryRun,
+        });
+
+      await run();
+
+      if (opts.watch) {
+        logger.info("Watch mode enabled", { interval: opts.interval });
+        setInterval(run, opts.interval * 60 * 1000);
+      }
     });
 
   return program;

--- a/src/improve/detectors/lint.ts
+++ b/src/improve/detectors/lint.ts
@@ -1,0 +1,97 @@
+import { execa } from "execa";
+import { access } from "node:fs/promises";
+import { join, relative } from "node:path";
+import type { Detector, Finding } from "../types.js";
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createLintDetector(): Detector {
+  return {
+    name: "lint",
+    async detect(cwd: string): Promise<Finding[]> {
+      const hasEslint = await fileExists(join(cwd, "eslint.config.js")).then(
+        (ok) => ok || fileExists(join(cwd, ".eslintrc.json")),
+      );
+      const hasBiome = await fileExists(join(cwd, "biome.json"));
+
+      if (hasEslint) {
+        return parseEslint(cwd);
+      }
+      if (hasBiome) {
+        return parseBiome(cwd);
+      }
+      return [];
+    },
+  };
+}
+
+async function parseEslint(cwd: string): Promise<Finding[]> {
+  const { stdout } = await execa("npx", ["eslint", ".", "--format", "json"], {
+    cwd,
+    reject: false,
+  });
+
+  try {
+    const results: Array<{
+      filePath: string;
+      messages: Array<{ ruleId: string | null; message: string; line: number; column: number }>;
+    }> = JSON.parse(stdout);
+
+    const findings: Finding[] = [];
+    for (const file of results) {
+      for (const msg of file.messages) {
+        const rule = msg.ruleId ?? "unknown";
+        const relPath = relative(cwd, file.filePath);
+        findings.push({
+          title: `[aidev] Lint: ${rule} in ${relPath}`,
+          body: `**Rule:** \`${rule}\`\n**File:** ${relPath}:${msg.line}\n**Message:** ${msg.message}`,
+          category: "lint",
+          filePath: relPath,
+        });
+      }
+    }
+    return findings;
+  } catch {
+    return [];
+  }
+}
+
+async function parseBiome(cwd: string): Promise<Finding[]> {
+  const { stdout } = await execa(
+    "npx",
+    ["biome", "lint", ".", "--reporter", "json"],
+    { cwd, reject: false },
+  );
+
+  try {
+    const result: {
+      diagnostics: Array<{
+        category: string;
+        message: string;
+        location?: { path?: { file?: string }; span?: { start?: { line?: number } } };
+      }>;
+    } = JSON.parse(stdout);
+
+    return result.diagnostics.map((d) => {
+      const filePath = d.location?.path?.file ?? "unknown";
+      const relPath = relative(cwd, filePath);
+      // Use relPath if it doesn't start with '..', otherwise use filePath as-is (already relative)
+      const displayPath = relPath.startsWith("..") ? filePath : relPath;
+      return {
+        title: `[aidev] Lint: ${d.category} in ${displayPath}`,
+        body: `**Rule:** \`${d.category}\`\n**File:** ${displayPath}\n**Message:** ${d.message}`,
+        category: "lint" as const,
+        filePath: displayPath,
+      };
+    });
+  } catch {
+    return [];
+  }
+}

--- a/src/improve/detectors/outdated.ts
+++ b/src/improve/detectors/outdated.ts
@@ -1,0 +1,81 @@
+import { execa } from "execa";
+import { access } from "node:fs/promises";
+import { join } from "node:path";
+import type { Detector, Finding } from "../types.js";
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isMajorBump(current: string, latest: string): boolean {
+  const currentMajor = current.split(".")[0];
+  const latestMajor = latest.split(".")[0];
+  return currentMajor !== latestMajor;
+}
+
+export function createOutdatedDetector(): Detector {
+  return {
+    name: "outdated",
+    async detect(cwd: string): Promise<Finding[]> {
+      const hasBun = await fileExists(join(cwd, "bun.lock"));
+      const hasNpm = await fileExists(join(cwd, "package-lock.json"));
+
+      if (hasBun) {
+        return parseBunOutdated(cwd);
+      }
+      if (hasNpm) {
+        return parseNpmOutdated(cwd);
+      }
+      return [];
+    },
+  };
+}
+
+async function parseBunOutdated(cwd: string): Promise<Finding[]> {
+  const { stdout } = await execa("bun", ["outdated", "--json"], {
+    cwd,
+    reject: false,
+  });
+
+  try {
+    const pkgs: Array<{ name: string; current: string; latest: string }> =
+      JSON.parse(stdout);
+
+    return pkgs
+      .filter((p) => isMajorBump(p.current, p.latest))
+      .map((p) => ({
+        title: `[aidev] Outdated: ${p.name} ${p.current} → ${p.latest}`,
+        body: `**Package:** ${p.name}\n**Current:** ${p.current}\n**Latest:** ${p.latest}\n\nMajor version update available.`,
+        category: "outdated" as const,
+      }));
+  } catch {
+    return [];
+  }
+}
+
+async function parseNpmOutdated(cwd: string): Promise<Finding[]> {
+  const { stdout } = await execa("npm", ["outdated", "--json"], {
+    cwd,
+    reject: false,
+  });
+
+  try {
+    const data: Record<string, { current: string; wanted: string; latest: string }> =
+      JSON.parse(stdout);
+
+    return Object.entries(data)
+      .filter(([, v]) => isMajorBump(v.current, v.latest))
+      .map(([name, v]) => ({
+        title: `[aidev] Outdated: ${name} ${v.current} → ${v.latest}`,
+        body: `**Package:** ${name}\n**Current:** ${v.current}\n**Latest:** ${v.latest}\n\nMajor version update available.`,
+        category: "outdated" as const,
+      }));
+  } catch {
+    return [];
+  }
+}

--- a/src/improve/detectors/todo.ts
+++ b/src/improve/detectors/todo.ts
@@ -1,0 +1,53 @@
+import { execa } from "execa";
+import type { Detector, Finding } from "../types.js";
+
+export function createTodoDetector(): Detector {
+  return {
+    name: "todo",
+    async detect(cwd: string): Promise<Finding[]> {
+      try {
+        const { stdout } = await execa(
+          "grep",
+          [
+            "-rn",
+            "--include=*.ts",
+            "--include=*.tsx",
+            "--include=*.js",
+            "--include=*.jsx",
+            "--exclude-dir=node_modules",
+            "--exclude-dir=dist",
+            "--exclude-dir=.git",
+            "-E",
+            "TODO|FIXME",
+            ".",
+          ],
+          { cwd },
+        );
+
+        if (!stdout.trim()) return [];
+
+        return stdout
+          .trim()
+          .split("\n")
+          .map((line) => {
+            // Format: ./src/utils.ts:10:  // TODO: refactor this function
+            const normalized = line.startsWith("./") ? line.slice(2) : line;
+            const firstColon = normalized.indexOf(":");
+            const secondColon = normalized.indexOf(":", firstColon + 1);
+            const filePath = normalized.slice(0, firstColon);
+            const lineNum = normalized.slice(firstColon + 1, secondColon);
+
+            return {
+              title: `[aidev] TODO in ${filePath}:${lineNum}`,
+              body: `Found TODO/FIXME comment:\n\n\`\`\`\n${normalized}\n\`\`\``,
+              category: "todo" as const,
+              filePath,
+            };
+          });
+      } catch {
+        // grep returns exit code 1 when no matches found
+        return [];
+      }
+    },
+  };
+}

--- a/src/improve/runner.ts
+++ b/src/improve/runner.ts
@@ -1,0 +1,57 @@
+import type { GitHubAdapter } from "../adapters/github.js";
+import type { Logger } from "../util/logger.js";
+import type { Detector, Finding } from "./types.js";
+
+export interface ImproveOptions {
+  cwd: string;
+  repo: string;
+  detectors: Detector[];
+  github: GitHubAdapter;
+  logger: Logger;
+  dryRun: boolean;
+}
+
+export async function runImprove(opts: ImproveOptions): Promise<void> {
+  const { detectors, github, logger, dryRun, cwd } = opts;
+
+  // Run all detectors
+  const allFindings: Finding[] = [];
+  for (const detector of detectors) {
+    logger.info("Running detector", { name: detector.name });
+    const findings = await detector.detect(cwd);
+    logger.info("Detector completed", { name: detector.name, count: findings.length });
+    allFindings.push(...findings);
+  }
+
+  if (allFindings.length === 0) {
+    logger.info("No findings detected");
+    return;
+  }
+
+  // Fetch existing open issues for deduplication
+  const existingIssues = await github.searchIssues("[aidev]");
+  const existingTitles = new Set(existingIssues.map((i) => i.title));
+
+  // Create issues for new findings
+  for (const finding of allFindings) {
+    if (existingTitles.has(finding.title)) {
+      logger.info("Skipping duplicate", { title: finding.title });
+      continue;
+    }
+
+    if (dryRun) {
+      logger.info("Dry run: would create issue", {
+        title: finding.title,
+        category: finding.category,
+      });
+      continue;
+    }
+
+    const issueNumber = await github.createIssue({
+      title: finding.title,
+      body: finding.body,
+      labels: ["auto-merge"],
+    });
+    logger.info("Created issue", { number: issueNumber, title: finding.title });
+  }
+}

--- a/src/improve/types.ts
+++ b/src/improve/types.ts
@@ -1,0 +1,11 @@
+export interface Finding {
+  title: string;
+  body: string;
+  category: "todo" | "lint" | "outdated";
+  filePath?: string;
+}
+
+export interface Detector {
+  name: string;
+  detect(cwd: string): Promise<Finding[]>;
+}

--- a/test/adapters/git.test.ts
+++ b/test/adapters/git.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createGitAdapter, type GitAdapter } from "../../src/adapters/git.js";
 
-const mockExeca = vi.fn();
+const { mockExeca } = vi.hoisted(() => ({
+  mockExeca: vi.fn(),
+}));
 vi.mock("execa", () => ({
   execa: mockExeca,
 }));

--- a/test/adapters/github.test.ts
+++ b/test/adapters/github.test.ts
@@ -4,7 +4,9 @@ import {
   type GitHubAdapter,
 } from "../../src/adapters/github.js";
 
-const mockExeca = vi.fn();
+const { mockExeca } = vi.hoisted(() => ({
+  mockExeca: vi.fn(),
+}));
 vi.mock("execa", () => ({
   execa: mockExeca,
 }));
@@ -245,6 +247,99 @@ describe("GitHubAdapter", () => {
       const issues = await gh.listIssuesByLabel("ai:run");
       expect(issues).toHaveLength(2);
       expect(issues[0]!.number).toBe(1);
+    });
+  });
+
+  describe("createIssue", () => {
+    it("calls gh issue create with correct args and labels", async () => {
+      mockExeca.mockResolvedValue({
+        stdout: "https://github.com/mizumura3/inko/issues/42\n",
+      } as any);
+
+      const issueNumber = await gh.createIssue({
+        title: "[aidev] Fix TODO in utils",
+        body: "Found a TODO comment",
+        labels: ["auto-merge", "improvement"],
+      });
+
+      expect(mockExeca).toHaveBeenCalledWith("gh", [
+        "issue",
+        "create",
+        "--repo",
+        repo,
+        "--title",
+        "[aidev] Fix TODO in utils",
+        "--body",
+        "Found a TODO comment",
+        "--label",
+        "auto-merge",
+        "--label",
+        "improvement",
+      ]);
+      expect(issueNumber).toBe(42);
+    });
+
+    it("creates issue with no labels", async () => {
+      mockExeca.mockResolvedValue({
+        stdout: "https://github.com/mizumura3/inko/issues/5\n",
+      } as any);
+
+      const issueNumber = await gh.createIssue({
+        title: "[aidev] Test",
+        body: "body",
+        labels: [],
+      });
+
+      expect(mockExeca).toHaveBeenCalledWith("gh", [
+        "issue",
+        "create",
+        "--repo",
+        repo,
+        "--title",
+        "[aidev] Test",
+        "--body",
+        "body",
+      ]);
+      expect(issueNumber).toBe(5);
+    });
+  });
+
+  describe("searchIssues", () => {
+    it("calls gh search issues with correct query and repo filter", async () => {
+      mockExeca.mockResolvedValue({
+        stdout: JSON.stringify([
+          { number: 10, title: "[aidev] Fix X", body: "details", labels: [{ name: "auto-merge" }] },
+        ]),
+      } as any);
+
+      const issues = await gh.searchIssues("[aidev] Fix X");
+
+      expect(mockExeca).toHaveBeenCalledWith("gh", [
+        "search",
+        "issues",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--json",
+        "number,title,body,labels",
+        "--",
+        "[aidev] Fix X",
+      ]);
+      expect(issues).toHaveLength(1);
+      expect(issues[0]).toEqual({
+        number: 10,
+        title: "[aidev] Fix X",
+        body: "details",
+        labels: ["auto-merge"],
+      });
+    });
+
+    it("returns empty array when no matching issues", async () => {
+      mockExeca.mockResolvedValue({ stdout: "[]" } as any);
+
+      const issues = await gh.searchIssues("[aidev] nonexistent");
+      expect(issues).toHaveLength(0);
     });
   });
 });

--- a/test/improve/detectors/lint.test.ts
+++ b/test/improve/detectors/lint.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createLintDetector } from "../../../src/improve/detectors/lint.js";
+import { access } from "node:fs/promises";
+
+const { mockExeca, mockAccess } = vi.hoisted(() => ({
+  mockExeca: vi.fn(),
+  mockAccess: vi.fn(),
+}));
+vi.mock("execa", () => ({
+  execa: mockExeca,
+}));
+vi.mock("node:fs/promises", () => ({
+  access: mockAccess,
+}));
+
+describe("LintDetector", () => {
+  const detector = createLintDetector();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("has name 'lint'", () => {
+    expect(detector.name).toBe("lint");
+  });
+
+  it("detects ESLint config and runs eslint --format json", async () => {
+    // eslint config exists
+    mockAccess.mockResolvedValueOnce(undefined);
+    // biome config does not exist
+    mockAccess.mockRejectedValueOnce(new Error("not found"));
+
+    mockExeca.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          filePath: "/tmp/repo/src/app.ts",
+          messages: [
+            { ruleId: "no-unused-vars", message: "x is unused", line: 5, column: 1 },
+          ],
+        },
+      ]),
+    });
+
+    const findings = await detector.detect("/tmp/repo");
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      "npx",
+      ["eslint", ".", "--format", "json"],
+      expect.objectContaining({ cwd: "/tmp/repo", reject: false }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toEqual({
+      title: "[aidev] Lint: no-unused-vars in src/app.ts",
+      body: expect.stringContaining("x is unused"),
+      category: "lint",
+      filePath: "src/app.ts",
+    });
+  });
+
+  it("detects biome config and runs biome lint --reporter json", async () => {
+    // eslint.config.js does not exist
+    mockAccess.mockRejectedValueOnce(new Error("not found"));
+    // .eslintrc.json does not exist (chained check)
+    mockAccess.mockRejectedValueOnce(new Error("not found"));
+    // biome.json exists
+    mockAccess.mockResolvedValueOnce(undefined);
+
+    mockExeca.mockResolvedValue({
+      stdout: JSON.stringify({
+        diagnostics: [
+          {
+            category: "lint/suspicious/noDoubleEquals",
+            message: "Use === instead of ==",
+            location: { path: { file: "src/utils.ts" }, span: { start: { line: 10 } } },
+          },
+        ],
+      }),
+    });
+
+    const findings = await detector.detect("/tmp/repo");
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      "npx",
+      ["biome", "lint", ".", "--reporter", "json"],
+      expect.objectContaining({ cwd: "/tmp/repo", reject: false }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toEqual({
+      title: "[aidev] Lint: lint/suspicious/noDoubleEquals in src/utils.ts",
+      body: expect.stringContaining("Use === instead of =="),
+      category: "lint",
+      filePath: "src/utils.ts",
+    });
+  });
+
+  it("returns empty array when no linter config found", async () => {
+    mockAccess.mockRejectedValue(new Error("not found"));
+
+    const findings = await detector.detect("/tmp/repo");
+    expect(findings).toEqual([]);
+    expect(mockExeca).not.toHaveBeenCalled();
+  });
+});

--- a/test/improve/detectors/outdated.test.ts
+++ b/test/improve/detectors/outdated.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createOutdatedDetector } from "../../../src/improve/detectors/outdated.js";
+
+const { mockExeca, mockAccess } = vi.hoisted(() => ({
+  mockExeca: vi.fn(),
+  mockAccess: vi.fn(),
+}));
+vi.mock("execa", () => ({
+  execa: mockExeca,
+}));
+vi.mock("node:fs/promises", () => ({
+  access: mockAccess,
+}));
+
+describe("OutdatedDetector", () => {
+  const detector = createOutdatedDetector();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("has name 'outdated'", () => {
+    expect(detector.name).toBe("outdated");
+  });
+
+  it("detects bun.lock and uses bun outdated", async () => {
+    // bun.lock exists
+    mockAccess.mockResolvedValueOnce(undefined);
+
+    mockExeca.mockResolvedValue({
+      stdout: JSON.stringify([
+        { name: "react", current: "17.0.2", latest: "18.2.0" },
+        { name: "lodash", current: "4.17.20", latest: "4.17.21" },
+      ]),
+    });
+
+    const findings = await detector.detect("/tmp/repo");
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      "bun",
+      ["outdated", "--json"],
+      expect.objectContaining({ cwd: "/tmp/repo", reject: false }),
+    );
+    // Only major version bumps
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toEqual({
+      title: "[aidev] Outdated: react 17.0.2 → 18.2.0",
+      body: expect.stringContaining("react"),
+      category: "outdated",
+    });
+  });
+
+  it("detects package-lock.json and uses npm outdated", async () => {
+    // bun.lock does not exist
+    mockAccess.mockRejectedValueOnce(new Error("not found"));
+    // package-lock.json exists
+    mockAccess.mockResolvedValueOnce(undefined);
+
+    // npm outdated --json outputs an object keyed by package name
+    mockExeca.mockResolvedValue({
+      stdout: JSON.stringify({
+        typescript: { current: "4.9.5", wanted: "4.9.5", latest: "5.3.2" },
+        vitest: { current: "3.0.0", wanted: "3.0.1", latest: "3.0.1" },
+      }),
+    });
+
+    const findings = await detector.detect("/tmp/repo");
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      "npm",
+      ["outdated", "--json"],
+      expect.objectContaining({ cwd: "/tmp/repo", reject: false }),
+    );
+    // Only major bumps: typescript 4→5
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toEqual({
+      title: "[aidev] Outdated: typescript 4.9.5 → 5.3.2",
+      body: expect.stringContaining("typescript"),
+      category: "outdated",
+    });
+  });
+
+  it("filters to only major version bumps", async () => {
+    mockAccess.mockRejectedValueOnce(new Error("not found"));
+    mockAccess.mockResolvedValueOnce(undefined);
+
+    mockExeca.mockResolvedValue({
+      stdout: JSON.stringify({
+        lodash: { current: "4.17.20", wanted: "4.17.21", latest: "4.17.21" },
+      }),
+    });
+
+    const findings = await detector.detect("/tmp/repo");
+    expect(findings).toHaveLength(0);
+  });
+
+  it("returns empty when no lock file found", async () => {
+    mockAccess.mockRejectedValue(new Error("not found"));
+
+    const findings = await detector.detect("/tmp/repo");
+    expect(findings).toEqual([]);
+    expect(mockExeca).not.toHaveBeenCalled();
+  });
+});

--- a/test/improve/detectors/todo.test.ts
+++ b/test/improve/detectors/todo.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTodoDetector } from "../../../src/improve/detectors/todo.js";
+
+const { mockExeca } = vi.hoisted(() => ({
+  mockExeca: vi.fn(),
+}));
+vi.mock("execa", () => ({
+  execa: mockExeca,
+}));
+
+describe("TodoDetector", () => {
+  const detector = createTodoDetector();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("has name 'todo'", () => {
+    expect(detector.name).toBe("todo");
+  });
+
+  it("correctly parses grep output into Findings with file paths and line numbers", async () => {
+    mockExeca.mockResolvedValue({
+      stdout: [
+        "src/utils.ts:10:  // TODO: refactor this function",
+        "src/index.ts:25:  // FIXME: handle edge case",
+      ].join("\n"),
+    });
+
+    const findings = await detector.detect("/tmp/repo");
+
+    expect(findings).toHaveLength(2);
+    expect(findings[0]).toEqual({
+      title: "[aidev] TODO in src/utils.ts:10",
+      body: "Found TODO/FIXME comment:\n\n```\nsrc/utils.ts:10:  // TODO: refactor this function\n```",
+      category: "todo",
+      filePath: "src/utils.ts",
+    });
+    expect(findings[1]).toEqual({
+      title: "[aidev] TODO in src/index.ts:25",
+      body: "Found TODO/FIXME comment:\n\n```\nsrc/index.ts:25:  // FIXME: handle edge case\n```",
+      category: "todo",
+      filePath: "src/index.ts",
+    });
+  });
+
+  it("returns empty array when no TODOs found", async () => {
+    mockExeca.mockRejectedValue(new Error("grep exit code 1"));
+
+    const findings = await detector.detect("/tmp/repo");
+    expect(findings).toEqual([]);
+  });
+
+  it("ignores node_modules and dist directories", async () => {
+    mockExeca.mockResolvedValue({ stdout: "" });
+
+    await detector.detect("/tmp/repo");
+
+    expect(mockExeca).toHaveBeenCalledWith(
+      "grep",
+      expect.arrayContaining([
+        "--exclude-dir=node_modules",
+        "--exclude-dir=dist",
+        "--exclude-dir=.git",
+      ]),
+      expect.objectContaining({ cwd: "/tmp/repo" }),
+    );
+  });
+});

--- a/test/improve/runner.test.ts
+++ b/test/improve/runner.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { runImprove } from "../../src/improve/runner.js";
+import type { Detector, Finding } from "../../src/improve/types.js";
+import type { GitHubAdapter } from "../../src/adapters/github.js";
+import type { Logger } from "../../src/util/logger.js";
+
+function makeGitHub(overrides?: Partial<GitHubAdapter>): GitHubAdapter {
+  return {
+    getIssue: vi.fn(),
+    commentOnIssue: vi.fn(),
+    createPr: vi.fn(),
+    getCiStatus: vi.fn(),
+    mergePr: vi.fn(),
+    closeIssue: vi.fn(),
+    listIssuesByLabel: vi.fn(),
+    getCheckRunLogs: vi.fn(),
+    createIssue: vi.fn().mockResolvedValue(99),
+    searchIssues: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+function makeLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function makeDetector(
+  name: string,
+  findings: Finding[],
+): Detector {
+  return { name, detect: vi.fn().mockResolvedValue(findings) };
+}
+
+describe("ImproveRunner", () => {
+  let github: GitHubAdapter;
+  let logger: Logger;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    github = makeGitHub();
+    logger = makeLogger();
+  });
+
+  it("calls all enabled detectors and collects Findings", async () => {
+    const d1 = makeDetector("todo", [
+      { title: "[aidev] TODO in src/a.ts:1", body: "body1", category: "todo", filePath: "src/a.ts" },
+    ]);
+    const d2 = makeDetector("lint", [
+      { title: "[aidev] Lint: no-unused-vars in src/b.ts", body: "body2", category: "lint", filePath: "src/b.ts" },
+    ]);
+
+    await runImprove({
+      cwd: "/tmp/repo",
+      repo: "owner/repo",
+      detectors: [d1, d2],
+      github,
+      logger,
+      dryRun: false,
+    });
+
+    expect(d1.detect).toHaveBeenCalledWith("/tmp/repo");
+    expect(d2.detect).toHaveBeenCalledWith("/tmp/repo");
+    expect(github.createIssue).toHaveBeenCalledTimes(2);
+  });
+
+  it("deduplicates against existing open issues by searching title prefix", async () => {
+    const finding: Finding = {
+      title: "[aidev] TODO in src/a.ts:1",
+      body: "body",
+      category: "todo",
+      filePath: "src/a.ts",
+    };
+    const detector = makeDetector("todo", [finding]);
+
+    // Existing open issue with matching title
+    vi.mocked(github.searchIssues).mockResolvedValue([
+      { number: 50, title: "[aidev] TODO in src/a.ts:1", body: "body", labels: ["auto-merge"] },
+    ]);
+
+    await runImprove({
+      cwd: "/tmp/repo",
+      repo: "owner/repo",
+      detectors: [detector],
+      github,
+      logger,
+      dryRun: false,
+    });
+
+    expect(github.createIssue).not.toHaveBeenCalled();
+  });
+
+  it("skips issue creation for findings that match existing open issues", async () => {
+    const findings: Finding[] = [
+      { title: "[aidev] TODO in src/a.ts:1", body: "body1", category: "todo", filePath: "src/a.ts" },
+      { title: "[aidev] TODO in src/b.ts:5", body: "body2", category: "todo", filePath: "src/b.ts" },
+    ];
+    const detector = makeDetector("todo", findings);
+
+    // Only first finding has existing issue
+    vi.mocked(github.searchIssues).mockResolvedValue([
+      { number: 50, title: "[aidev] TODO in src/a.ts:1", body: "body", labels: [] },
+    ]);
+
+    await runImprove({
+      cwd: "/tmp/repo",
+      repo: "owner/repo",
+      detectors: [detector],
+      github,
+      logger,
+      dryRun: false,
+    });
+
+    // Only one issue created (for the non-duplicate)
+    expect(github.createIssue).toHaveBeenCalledTimes(1);
+    expect(github.createIssue).toHaveBeenCalledWith({
+      title: "[aidev] TODO in src/b.ts:5",
+      body: "body2",
+      labels: ["auto-merge"],
+    });
+  });
+
+  it("creates issues with correct title format, body template, and auto-merge label", async () => {
+    const finding: Finding = {
+      title: "[aidev] TODO in src/a.ts:1",
+      body: "some body",
+      category: "todo",
+      filePath: "src/a.ts",
+    };
+    const detector = makeDetector("todo", [finding]);
+
+    await runImprove({
+      cwd: "/tmp/repo",
+      repo: "owner/repo",
+      detectors: [detector],
+      github,
+      logger,
+      dryRun: false,
+    });
+
+    expect(github.createIssue).toHaveBeenCalledWith({
+      title: "[aidev] TODO in src/a.ts:1",
+      body: "some body",
+      labels: ["auto-merge"],
+    });
+  });
+
+  it("in dry-run mode logs findings without creating issues", async () => {
+    const finding: Finding = {
+      title: "[aidev] TODO in src/a.ts:1",
+      body: "body",
+      category: "todo",
+      filePath: "src/a.ts",
+    };
+    const detector = makeDetector("todo", [finding]);
+
+    await runImprove({
+      cwd: "/tmp/repo",
+      repo: "owner/repo",
+      detectors: [detector],
+      github,
+      logger,
+      dryRun: true,
+    });
+
+    expect(github.createIssue).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `aidev improve` command that scans repositories for improvements and auto-creates GitHub Issues
- Implement 3 detectors: TODO/FIXME comments (grep), lint warnings (eslint/biome), outdated dependencies (npm/bun)
- Runner orchestrates detection, deduplicates against existing open issues by `[aidev]` title prefix, and creates issues with `auto-merge` label
- CLI supports `--repo`, `--dry-run`, `--watch`, `--interval`, `--detectors` options
- Add `createIssue` and `searchIssues` methods to `GitHubAdapter`
- Fix pre-existing `vi.hoisted` issue in `git.test.ts`

## Test plan

- [x] TODO detector parses grep output into Findings with file paths and line numbers
- [x] TODO detector returns empty array when no TODOs found
- [x] TODO detector ignores node_modules and dist directories
- [x] Lint detector detects ESLint config and runs eslint --format json
- [x] Lint detector detects biome config and runs biome lint --reporter json
- [x] Lint detector returns empty array when no linter config found
- [x] Outdated detector detects bun.lock and uses bun outdated
- [x] Outdated detector detects package-lock.json and uses npm outdated
- [x] Outdated detector filters to only major version bumps
- [x] Runner calls all enabled detectors and collects Findings
- [x] Runner deduplicates against existing open issues
- [x] Runner skips issue creation for duplicate findings
- [x] Runner creates issues with correct title, body, and auto-merge label
- [x] Runner dry-run mode logs without creating issues
- [x] GitHubAdapter.createIssue calls correct gh CLI commands
- [x] GitHubAdapter.searchIssues calls correct gh CLI commands
- [x] All 109 tests pass, TypeScript compiles cleanly

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)