### PR TITLE
fix: treat zero check runs as passing instead of pending

### DIFF
--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -90,7 +90,7 @@ export function createGitHubAdapter(repo: string): GitHubAdapter {
       const checks: Array<{ status: string; conclusion: string | null }> =
         JSON.parse(stdout);
 
-      if (checks.length === 0) return "pending";
+      if (checks.length === 0) return "passing";
       if (checks.some((c) => c.conclusion === "failure")) return "failing";
       if (checks.some((c) => c.status !== "completed")) return "pending";
       return "passing";

--- a/test/adapters/github.test.ts
+++ b/test/adapters/github.test.ts
@@ -113,10 +113,10 @@ describe("GitHubAdapter", () => {
       expect(status).toBe("pending");
     });
 
-    it("returns pending when no checks exist (push race condition)", async () => {
+    it("returns passing when no checks exist (no CI configured)", async () => {
       mockExeca.mockResolvedValue({ stdout: "[]" } as any);
       const status = await gh.getCiStatus("feature/x");
-      expect(status).toBe("pending");
+      expect(status).toBe("passing");
     });
   });
 


### PR DESCRIPTION
## Summary

- CI が設定されていないリポジトリで `watching_ci` が 10 分タイムアウトする問題を修正
- `getCiStatus` で check runs が 0 件の場合、`"pending"` → `"passing"` に変更
- PR #14 (Issue #12) で実際に発生した問題

## Test plan

- [x] `getCiStatus` で check runs 0 件 → `"passing"` を返すテスト
- [x] 87 tests all GREEN, tsc build clean

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)