### PR TITLE
ci: add GitHub Actions workflow for build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun test


### PR DESCRIPTION
## Summary
- Add CI workflow (`.github/workflows/ci.yml`) triggered on PRs and pushes to main
- **lint** job: runs `bun run build` (tsc) to catch TypeScript compilation errors
- **test** job: runs `bun test` (vitest run) to catch test failures
- Uses `oven-sh/setup-bun@v2` and `bun install --frozen-lockfile` for reproducible builds

## Test plan
- [x] YAML syntax validated
- [x] `bun run build` passes locally
- [x] `bun test` passes locally (87 tests, 0 failures)
- [ ] Verify CI runs on this PR after push

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)