### PR TITLE
feat: add markdown format instructions for planner investigation output

### DIFF
--- a/src/agents/planner.ts
+++ b/src/agents/planner.ts
@@ -24,6 +24,11 @@ IMPORTANT: First, explore the codebase to understand the structure. Then output 
 Required JSON schema:
 {"summary":"string","steps":["string"],"filesToTouch":["string"],"tests":["string"],"risks":["string"],"acceptanceCriteria":["string"],"investigation":"string - detailed findings from your codebase analysis (what you found, root cause, relevant code paths)"}
 
+Format rules for the "investigation" field:
+- Use Markdown bullet list (\`-\` items) to structure your findings
+- Wrap file paths, function names, and code snippets in backticks for inline code
+- Separate logical sections (e.g. root cause, relevant code, affected areas) with blank lines and bold headers (\`**Header**\`)
+
 Your final message must contain ONLY the JSON object, nothing else.`;
 
   logger.info("Running planner agent", { issue: input.issue.number });

--- a/test/agents/planner.test.ts
+++ b/test/agents/planner.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockQuery, mockExtractJson } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+  mockExtractJson: vi.fn(),
+}));
+
+vi.mock("@anthropic-ai/claude-code", () => ({
+  query: mockQuery,
+}));
+
+vi.mock("../../src/agents/shared.js", () => ({
+  createSafetyHook: () => ({ command: "true" }),
+  extractJson: mockExtractJson,
+  getBaseSdkOptions: () => ({ pathToClaudeCodeExecutable: "/usr/bin/claude" }),
+}));
+
+import { runPlanner } from "../../src/agents/planner.js";
+
+const noopLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+describe("runPlanner prompt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("includes investigation format instructions for markdown lists and inline code", async () => {
+    let capturedPrompt = "";
+    mockQuery.mockImplementation(({ prompt }: { prompt: string }) => {
+      capturedPrompt = prompt;
+      return (async function* () {
+        yield {
+          type: "result",
+          subtype: "success",
+          result: "{}",
+        };
+      })();
+    });
+
+    mockExtractJson.mockReturnValue({
+      summary: "s",
+      steps: ["a"],
+      filesToTouch: [],
+      tests: [],
+      risks: [],
+      acceptanceCriteria: [],
+      investigation: "test",
+    });
+
+    await runPlanner(
+      { issue: { number: 1, title: "Test", body: "body", labels: [] }, cwd: "/tmp" },
+      noopLogger as any
+    );
+
+    // Verify the prompt instructs markdown bullet list format for investigation
+    expect(capturedPrompt).toContain("investigation");
+    expect(capturedPrompt).toMatch(/bullet|`-`|list/i);
+    expect(capturedPrompt).toMatch(/backtick|inline code|`/);
+  });
+});


### PR DESCRIPTION
## Summary

- Add Markdown formatting instructions (bullet lists, inline code, bold headers) to the planner agent's prompt for the `investigation` field
- Add unit test that verifies the prompt contains the new formatting instructions
- No changes to `states.ts` needed — the investigation text is already posted as-is to GitHub Issues, so structured Markdown renders correctly

## Test plan

- [x] New test `test/agents/planner.test.ts` verifies prompt contains bullet list and inline code instructions
- [x] All existing tests pass (`vitest run` — 68 tests pass; 2 pre-existing adapter test failures unrelated to this change)
- [x] TypeScript build (`tsc --noEmit`) passes

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)