### PR TITLE
feat: add grace period for CI check runs registration in watching_ci

### DIFF
--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -14,7 +14,7 @@ export interface CreatePrOpts {
   base: string;
 }
 
-export type CiStatus = "passing" | "failing" | "pending";
+export type CiStatus = "passing" | "failing" | "pending" | "no_checks";
 
 export interface GitHubAdapter {
   getIssue(number: number): Promise<Issue>;
@@ -90,7 +90,7 @@ export function createGitHubAdapter(repo: string): GitHubAdapter {
       const checks: Array<{ status: string; conclusion: string | null }> =
         JSON.parse(stdout);
 
-      if (checks.length === 0) return "passing";
+      if (checks.length === 0) return "no_checks";
       if (checks.some((c) => c.conclusion === "failure")) return "failing";
       if (checks.some((c) => c.status !== "completed")) return "pending";
       return "passing";

--- a/src/workflow/states.ts
+++ b/src/workflow/states.ts
@@ -118,6 +118,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
     if (!ctx.prNumber) throw new Error("No PR number");
     const maxWait = 10 * 60 * 1000; // 10 minutes
     const pollInterval = 15 * 1000; // 15 seconds
+    const gracePeriod = 30 * 1000; // 30 seconds for CI check runs to register
     const start = Date.now();
 
     while (Date.now() - start < maxWait) {
@@ -136,6 +137,11 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
         return transition(ctx, "fixing", {
           fixAttempts: ctx.fixAttempts + 1,
         });
+      }
+      if (status === "no_checks" && Date.now() - start >= gracePeriod) {
+        logger.info("No CI checks found after grace period, treating as passing");
+        if (!shouldAutoMerge(ctx)) return transition(ctx, "done");
+        return transition(ctx, "merging");
       }
       await new Promise((r) => setTimeout(r, pollInterval));
     }

--- a/test/adapters/github.test.ts
+++ b/test/adapters/github.test.ts
@@ -4,7 +4,9 @@ import {
   type GitHubAdapter,
 } from "../../src/adapters/github.js";
 
-const mockExeca = vi.fn();
+const { mockExeca } = vi.hoisted(() => ({
+  mockExeca: vi.fn(),
+}));
 vi.mock("execa", () => ({
   execa: mockExeca,
 }));
@@ -113,10 +115,10 @@ describe("GitHubAdapter", () => {
       expect(status).toBe("pending");
     });
 
-    it("returns passing when no checks exist (no CI configured)", async () => {
+    it("returns no_checks when no checks exist", async () => {
       mockExeca.mockResolvedValue({ stdout: "[]" } as any);
       const status = await gh.getCiStatus("feature/x");
-      expect(status).toBe("passing");
+      expect(status).toBe("no_checks");
     });
   });
 

--- a/test/workflow/states.test.ts
+++ b/test/workflow/states.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createStateHandlers, type Deps } from "../../src/workflow/states.js";
 import type { RunContext } from "../../src/types.js";
 import type { GitAdapter } from "../../src/adapters/git.js";
@@ -136,5 +136,123 @@ describe("watching_ci handler", () => {
     const result = await handlers.watching_ci!(ctx);
 
     expect(result.nextState).toBe("done");
+  });
+
+  describe("no_checks grace period", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("keeps polling when no_checks is returned during grace period", async () => {
+      const getCiStatus = vi.fn();
+      // First call: no_checks (within grace period), second call: passing
+      getCiStatus.mockResolvedValueOnce("no_checks");
+      getCiStatus.mockResolvedValueOnce("passing");
+
+      const deps = makeDeps({ github: { getCiStatus } });
+      const handlers = createStateHandlers(deps);
+      const ctx = makeCtx({
+        state: "watching_ci",
+        prNumber: 42,
+        autoMerge: true,
+      });
+
+      const promise = handlers.watching_ci!(ctx);
+      // Advance past the poll interval (15s) to trigger second poll
+      await vi.advanceTimersByTimeAsync(15_000);
+      const result = await promise;
+
+      expect(getCiStatus).toHaveBeenCalledTimes(2);
+      expect(result.nextState).toBe("merging");
+    });
+
+    it("treats no_checks as passing after grace period expires", async () => {
+      const getCiStatus = vi.fn().mockResolvedValue("no_checks");
+
+      const deps = makeDeps({ github: { getCiStatus } });
+      const handlers = createStateHandlers(deps);
+      const ctx = makeCtx({
+        state: "watching_ci",
+        prNumber: 42,
+        autoMerge: true,
+      });
+
+      const promise = handlers.watching_ci!(ctx);
+      // Advance past the grace period (30s) + poll intervals
+      // First poll at 0s: no_checks (within grace, wait 15s)
+      // Second poll at 15s: no_checks (within grace, wait 15s)
+      await vi.advanceTimersByTimeAsync(15_000);
+      // Third poll at 30s: no_checks (grace period exceeded, treat as passing)
+      await vi.advanceTimersByTimeAsync(15_000);
+      const result = await promise;
+
+      expect(result.nextState).toBe("merging");
+    });
+
+    it("transitions to done when no_checks after grace period and no auto-merge", async () => {
+      const getCiStatus = vi.fn().mockResolvedValue("no_checks");
+
+      const deps = makeDeps({ github: { getCiStatus } });
+      const handlers = createStateHandlers(deps);
+      const ctx = makeCtx({
+        state: "watching_ci",
+        prNumber: 42,
+        autoMerge: false,
+        issueLabels: [],
+      });
+
+      const promise = handlers.watching_ci!(ctx);
+      await vi.advanceTimersByTimeAsync(15_000);
+      await vi.advanceTimersByTimeAsync(15_000);
+      const result = await promise;
+
+      expect(result.nextState).toBe("done");
+    });
+
+    it("transitions correctly when no_checks is followed by real passing", async () => {
+      const getCiStatus = vi.fn();
+      getCiStatus.mockResolvedValueOnce("no_checks");
+      getCiStatus.mockResolvedValueOnce("passing");
+
+      const deps = makeDeps({ github: { getCiStatus } });
+      const handlers = createStateHandlers(deps);
+      const ctx = makeCtx({
+        state: "watching_ci",
+        prNumber: 42,
+        autoMerge: true,
+      });
+
+      const promise = handlers.watching_ci!(ctx);
+      await vi.advanceTimersByTimeAsync(15_000);
+      const result = await promise;
+
+      expect(getCiStatus).toHaveBeenCalledTimes(2);
+      expect(result.nextState).toBe("merging");
+    });
+
+    it("transitions to fixing when no_checks is followed by failing", async () => {
+      const getCiStatus = vi.fn();
+      getCiStatus.mockResolvedValueOnce("no_checks");
+      getCiStatus.mockResolvedValueOnce("failing");
+
+      const deps = makeDeps({ github: { getCiStatus } });
+      const handlers = createStateHandlers(deps);
+      const ctx = makeCtx({
+        state: "watching_ci",
+        prNumber: 42,
+        autoMerge: true,
+      });
+
+      const promise = handlers.watching_ci!(ctx);
+      await vi.advanceTimersByTimeAsync(15_000);
+      const result = await promise;
+
+      expect(getCiStatus).toHaveBeenCalledTimes(2);
+      expect(result.nextState).toBe("fixing");
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Added `"no_checks"` to the `CiStatus` union type to distinguish zero check runs from all-checks-passing
- `getCiStatus` returns `"no_checks"` instead of `"passing"` when `checks.length === 0`
- `watching_ci` handler adds a 30-second grace period: treats `"no_checks"` as pending during grace period, then as passing after it expires
- Fixed pre-existing `vi.hoisted` mock issue in `github.test.ts`

## Test plan

- [x] `getCiStatus` returns `"no_checks"` when check runs array is empty
- [x] `watching_ci` keeps polling when `"no_checks"` during grace period
- [x] `watching_ci` treats `"no_checks"` as passing after 30s grace period expires
- [x] `watching_ci` transitions correctly when `"no_checks"` followed by real `"passing"`
- [x] `watching_ci` transitions to fixing when `"no_checks"` followed by `"failing"`
- [x] Existing tests still pass

Fixes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)