### PR TITLE
feat: replace execaCommand with direct runWorkflow invocation in watch command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -176,7 +176,13 @@ export function createCli() {
       if (opts.claudePath) process.env.CLAUDE_EXECUTABLE = opts.claudePath;
       const logger = createLogger("info");
       const repo = opts.repo ?? detectRepo(opts.cwd);
+      const cwd = opts.cwd;
+      const baseDir = join(process.env.HOME ?? "~", ".devloop", "runs");
+
+      const git = createGitAdapter();
       const github = createGitHubAdapter(repo);
+      const persistence = createFilePersistence(baseDir);
+      const handlers = createStateHandlers({ git, github, logger });
 
       logger.info("Watching for issues", { label: opts.label, repo });
 
@@ -192,19 +198,25 @@ export function createCli() {
             title: issue.title,
           });
 
-          // Spawn a run for this issue
-          const { execaCommand } = await import("execa");
-          const args = [
-            "run",
-            "--issue",
-            String(issue.number),
-            "--cwd",
-            opts.cwd,
-            "--repo",
+          const runId = `run-${Date.now()}-${randomUUID().slice(0, 8)}`;
+          const ctx: RunContext = {
+            runId,
+            issueNumber: issue.number,
             repo,
-          ];
-          execaCommand(`devloop ${args.join(" ")}`, {
-            stdio: "inherit",
+            cwd,
+            state: "init",
+            branch: `aidev/issue-${issue.number}`,
+            maxFixAttempts: 3,
+            fixAttempts: 0,
+            dryRun: false,
+            autoMerge: false,
+            issueLabels: issue.labels,
+          };
+
+          runWorkflow(ctx, handlers, persistence, {
+            logger,
+            onTransition: (from, to) =>
+              logger.info("State transition", { from, to }),
           }).catch((err) =>
             logger.error("Run failed", {
               issue: issue.number,

--- a/test/cli-watch.test.ts
+++ b/test/cli-watch.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock modules before any imports
+vi.mock("../src/adapters/git.js", () => ({
+  createGitAdapter: vi.fn(() => ({ checkout: vi.fn(), push: vi.fn() })),
+}));
+
+vi.mock("../src/adapters/github.js", () => ({
+  createGitHubAdapter: vi.fn(() => ({
+    listIssuesByLabel: vi.fn(async () => []),
+    getIssue: vi.fn(),
+    commentOnIssue: vi.fn(),
+    createPr: vi.fn(),
+    getCiStatus: vi.fn(),
+    mergePr: vi.fn(),
+    closeIssue: vi.fn(),
+    getCheckRunLogs: vi.fn(),
+  })),
+}));
+
+vi.mock("../src/workflow/states.js", () => ({
+  createStateHandlers: vi.fn(() => ({
+    init: vi.fn(async (ctx: any) => ({
+      nextState: "done",
+      ctx: { ...ctx, state: "done" },
+    })),
+  })),
+}));
+
+vi.mock("../src/workflow/engine.js", () => ({
+  runWorkflow: vi.fn(async (ctx: any) => ({ ...ctx, state: "done" })),
+}));
+
+import { createCli } from "../src/cli.js";
+import { createGitAdapter } from "../src/adapters/git.js";
+import { createGitHubAdapter } from "../src/adapters/github.js";
+import { createStateHandlers } from "../src/workflow/states.js";
+import { runWorkflow } from "../src/workflow/engine.js";
+
+describe("watch command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Prevent process.exit from actually exiting
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls runWorkflow directly instead of execaCommand for each new issue", async () => {
+    const mockGithub = {
+      listIssuesByLabel: vi.fn(async () => [
+        { number: 42, title: "Test issue", body: "body", labels: ["ai:run"] },
+      ]),
+      getIssue: vi.fn(),
+      commentOnIssue: vi.fn(),
+      createPr: vi.fn(),
+      getCiStatus: vi.fn(),
+      mergePr: vi.fn(),
+      closeIssue: vi.fn(),
+      getCheckRunLogs: vi.fn(),
+    };
+    vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
+
+    const mockRunWorkflow = vi.mocked(runWorkflow);
+    mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+      ...ctx,
+      state: "done",
+    }));
+
+    // Use a single poll (avoid setInterval) by clearing the interval
+    const clearIntervalSpy = vi.spyOn(global, "clearInterval");
+    const originalSetInterval = global.setInterval;
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+    vi.spyOn(global, "setInterval").mockImplementation(((
+      fn: Function,
+      ms: number
+    ) => {
+      intervalId = originalSetInterval(() => {}, ms);
+      return intervalId;
+    }) as any);
+
+    const cli = createCli();
+    await cli.parseAsync([
+      "node",
+      "aidev",
+      "watch",
+      "--repo",
+      "owner/repo",
+      "--interval",
+      "999",
+    ]);
+
+    // Wait for fire-and-forget runWorkflow to complete
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(createGitAdapter).toHaveBeenCalled();
+    expect(createStateHandlers).toHaveBeenCalled();
+    expect(mockRunWorkflow).toHaveBeenCalledTimes(1);
+
+    // Verify the RunContext passed to runWorkflow
+    const ctx = mockRunWorkflow.mock.calls[0][0];
+    expect(ctx.issueNumber).toBe(42);
+    expect(ctx.repo).toBe("owner/repo");
+    expect(ctx.state).toBe("init");
+    expect(ctx.branch).toBe("aidev/issue-42");
+    expect(ctx.runId).toMatch(/^run-/);
+
+    // Clean up interval
+    if (intervalId) clearInterval(intervalId);
+  });
+
+  it("does not use execaCommand or reference devloop", async () => {
+    // This test verifies at the source level that execa is not imported in the watch command
+    const { readFile } = await import("node:fs/promises");
+    const source = await readFile(
+      new URL("../src/cli.ts", import.meta.url),
+      "utf-8"
+    );
+
+    // The watch command block should not contain execaCommand or spawn via 'devloop' CLI
+    // Find the watch command section
+    const watchStart = source.indexOf('.command("watch")');
+    const watchEnd = source.indexOf('.command("status")');
+    const watchSection = source.slice(watchStart, watchEnd);
+
+    expect(watchSection).not.toContain("execaCommand");
+    expect(watchSection).not.toContain("import(\"execa\")");
+    expect(watchSection).not.toContain("import('execa')");
+    // Should not spawn 'devloop' as a subprocess command
+    expect(watchSection).not.toMatch(/devloop\s+run/);
+  });
+
+  it("logs errors from runWorkflow without crashing the watcher", async () => {
+    const mockGithub = {
+      listIssuesByLabel: vi.fn(async () => [
+        { number: 99, title: "Failing issue", body: "body", labels: ["ai:run"] },
+      ]),
+      getIssue: vi.fn(),
+      commentOnIssue: vi.fn(),
+      createPr: vi.fn(),
+      getCiStatus: vi.fn(),
+      mergePr: vi.fn(),
+      closeIssue: vi.fn(),
+      getCheckRunLogs: vi.fn(),
+    };
+    vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
+
+    const mockRunWorkflow = vi.mocked(runWorkflow);
+    mockRunWorkflow.mockRejectedValue(new Error("workflow failed"));
+
+    const originalSetInterval = global.setInterval;
+    vi.spyOn(global, "setInterval").mockImplementation(((
+      fn: Function,
+      ms: number
+    ) => {
+      return originalSetInterval(() => {}, ms);
+    }) as any);
+
+    const cli = createCli();
+    // This should not throw even though runWorkflow rejects
+    await cli.parseAsync([
+      "node",
+      "aidev",
+      "watch",
+      "--repo",
+      "owner/repo",
+      "--interval",
+      "999",
+    ]);
+
+    // Wait for fire-and-forget to settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockRunWorkflow).toHaveBeenCalledTimes(1);
+    // The watcher should still be alive (no throw)
+  });
+
+  it("creates unique runIds for each issue", async () => {
+    const mockGithub = {
+      listIssuesByLabel: vi.fn(async () => [
+        { number: 10, title: "Issue 10", body: "body", labels: ["ai:run"] },
+        { number: 20, title: "Issue 20", body: "body", labels: ["ai:run"] },
+      ]),
+      getIssue: vi.fn(),
+      commentOnIssue: vi.fn(),
+      createPr: vi.fn(),
+      getCiStatus: vi.fn(),
+      mergePr: vi.fn(),
+      closeIssue: vi.fn(),
+      getCheckRunLogs: vi.fn(),
+    };
+    vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
+
+    const mockRunWorkflow = vi.mocked(runWorkflow);
+    mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+      ...ctx,
+      state: "done",
+    }));
+
+    const originalSetInterval = global.setInterval;
+    vi.spyOn(global, "setInterval").mockImplementation(((
+      fn: Function,
+      ms: number
+    ) => {
+      return originalSetInterval(() => {}, ms);
+    }) as any);
+
+    const cli = createCli();
+    await cli.parseAsync([
+      "node",
+      "aidev",
+      "watch",
+      "--repo",
+      "owner/repo",
+      "--interval",
+      "999",
+    ]);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockRunWorkflow).toHaveBeenCalledTimes(2);
+
+    const ctx1 = mockRunWorkflow.mock.calls[0][0];
+    const ctx2 = mockRunWorkflow.mock.calls[1][0];
+
+    expect(ctx1.runId).not.toBe(ctx2.runId);
+    expect(ctx1.issueNumber).toBe(10);
+    expect(ctx1.branch).toBe("aidev/issue-10");
+    expect(ctx2.issueNumber).toBe(20);
+    expect(ctx2.branch).toBe("aidev/issue-20");
+  });
+});


### PR DESCRIPTION
## Summary
- Replaced `execaCommand('devloop run ...')` in the watch command with direct `runWorkflow()` invocation
- The watch command now creates `createGitAdapter()`, `createFilePersistence()`, and `createStateHandlers()` once at startup, then constructs a unique `RunContext` per discovered issue
- Preserves the fire-and-forget async pattern with `.catch()` error logging
- Added 4 new tests in `test/cli-watch.test.ts` covering the new behavior

## Test plan
- [x] All 97 tests pass (`npm test`)
- [x] TypeScript build succeeds (`npm run build`)
- [x] New tests verify `runWorkflow` is called directly with correct `RunContext`
- [x] New tests verify no `execaCommand` or `devloop run` references remain in watch command
- [x] New tests verify error resilience (workflow failures are logged, don't crash watcher)
- [x] New tests verify unique `runId` and correct `branch` naming per issue

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)