### PR TITLE
feat: add documenter agent to auto-update docs

### DIFF
--- a/src/agents/documenter.ts
+++ b/src/agents/documenter.ts
@@ -1,0 +1,52 @@
+import { query } from "@anthropic-ai/claude-code";
+import type { Result } from "../types.js";
+import { createSafetyHook, getBaseSdkOptions } from "./shared.js";
+import type { Logger } from "../util/logger.js";
+
+export interface DocumenterInput {
+  result: Result;
+  cwd: string;
+}
+
+export async function runDocumenter(
+  input: DocumenterInput,
+  logger: Logger
+): Promise<void> {
+  const { result, cwd } = input;
+
+  const prompt = `You are a documentation update agent. Your job is to check if documentation (especially README.md) needs updating based on recent code changes.
+
+Changed files:
+${result.changedFiles.map((f) => `- ${f}`).join("\n")}
+
+Change summary:
+${result.changeSummary}
+
+Instructions:
+1. Read the current README.md (and any other relevant docs).
+2. Compare it against the changes described above.
+3. If the changes affect user-facing behavior (CLI options, commands, workflows, configuration, API), update the documentation to reflect the new behavior.
+4. If the changes are purely internal (refactoring, test additions, internal bug fixes) and do not affect user-facing behavior, do nothing — no update is needed.
+5. Only update sections that are directly affected. Do not rewrite unrelated parts.
+6. Keep the existing style and formatting of the documentation.`;
+
+  logger.info("Running documenter agent");
+
+  const response = query({
+    prompt,
+    options: {
+      ...getBaseSdkOptions(),
+      cwd,
+      permissionMode: "bypassPermissions",
+      allowedTools: ["Read", "Glob", "Grep", "Write", "Edit"],
+      hooks: { PreToolUse: [createSafetyHook()] },
+      maxTurns: 10,
+    },
+  });
+
+  for await (const message of response) {
+    if (message.type === "result" && message.subtype === "success") {
+      logger.info("Documenter completed", { result: message.result.slice(0, 200) });
+    }
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { createGitHubAdapter } from "./adapters/github.js";
 import { createLogger } from "./util/logger.js";
 import { runWorkflow, type Persistence } from "./workflow/engine.js";
 import { createStateHandlers } from "./workflow/states.js";
+import { runDocumenter } from "./agents/documenter.js";
 import type { RunContext } from "./types.js";
 
 function createFilePersistence(baseDir: string): Persistence {
@@ -146,7 +147,7 @@ export function createCli() {
 
       const git = createGitAdapter();
       const github = createGitHubAdapter(ctx.repo);
-      const handlers = createStateHandlers({ git, github, logger });
+      const handlers = createStateHandlers({ git, github, logger, runDocumenter });
 
       logger.info("Starting devloop", { runId: ctx.runId, issue: opts.issue, repo: ctx.repo });
 
@@ -182,7 +183,7 @@ export function createCli() {
       const git = createGitAdapter();
       const github = createGitHubAdapter(repo);
       const persistence = createFilePersistence(baseDir);
-      const handlers = createStateHandlers({ git, github, logger });
+      const handlers = createStateHandlers({ git, github, logger, runDocumenter });
 
       logger.info("Watching for issues", { label: opts.label, repo });
 

--- a/src/workflow/states.ts
+++ b/src/workflow/states.ts
@@ -7,11 +7,13 @@ import { runImplementer } from "../agents/implementer.js";
 import { runReviewer } from "../agents/reviewer.js";
 import { runFixer } from "../agents/fixer.js";
 import type { Logger } from "../util/logger.js";
+import type { DocumenterInput } from "../agents/documenter.js";
 
 export interface Deps {
   git: GitAdapter;
   github: GitHubAdapter;
   logger: Logger;
+  runDocumenter: (input: DocumenterInput, logger: Logger) => Promise<void>;
 }
 
 function transition(
@@ -27,7 +29,7 @@ function shouldAutoMerge(ctx: RunContext): boolean {
 }
 
 export function createStateHandlers(deps: Deps): StateHandlerMap {
-  const { git, github, logger } = deps;
+  const { git, github, logger, runDocumenter } = deps;
 
   const init: StateHandler = async (ctx) => {
     const issue = await github.getIssue(ctx.issueNumber);
@@ -90,6 +92,8 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
 
   const committing: StateHandler = async (ctx) => {
     if (!ctx.result) throw new Error("No result available");
+    await runDocumenter({ result: ctx.result, cwd: ctx.cwd }, logger);
+    logger.info("Documentation check completed");
     await git.addAll(ctx.cwd);
     await git.commit(ctx.result.commitMessageDraft, ctx.cwd);
     logger.info("Committed changes");

--- a/test/agents/documenter.test.ts
+++ b/test/agents/documenter.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockQuery } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+}));
+
+vi.mock("@anthropic-ai/claude-code", () => ({
+  query: mockQuery,
+}));
+
+vi.mock("../../src/agents/shared.js", () => ({
+  createSafetyHook: () => ({ command: "true" }),
+  getBaseSdkOptions: () => ({ pathToClaudeCodeExecutable: "/usr/bin/claude" }),
+}));
+
+import { runDocumenter } from "../../src/agents/documenter.js";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+describe("runDocumenter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes changedFiles and changeSummary in the prompt", async () => {
+    let capturedPrompt = "";
+    mockQuery.mockImplementation(({ prompt }: { prompt: string }) => {
+      capturedPrompt = prompt;
+      return (async function* () {
+        yield { type: "result", subtype: "success", result: "" };
+      })();
+    });
+
+    await runDocumenter(
+      {
+        result: {
+          changeSummary: "Added watch --interval flag",
+          changedFiles: ["src/cli.ts", "src/workflow/engine.ts"],
+          testsRun: true,
+          commitMessageDraft: "feat: add interval flag",
+          prBodyDraft: "",
+        },
+        cwd: "/tmp/repo",
+      },
+      noopLogger as any
+    );
+
+    expect(capturedPrompt).toContain("Added watch --interval flag");
+    expect(capturedPrompt).toContain("src/cli.ts");
+    expect(capturedPrompt).toContain("src/workflow/engine.ts");
+  });
+
+  it("instructs to update README when user-facing changes exist", async () => {
+    let capturedPrompt = "";
+    mockQuery.mockImplementation(({ prompt }: { prompt: string }) => {
+      capturedPrompt = prompt;
+      return (async function* () {
+        yield { type: "result", subtype: "success", result: "" };
+      })();
+    });
+
+    await runDocumenter(
+      {
+        result: {
+          changeSummary: "Refactored internals",
+          changedFiles: ["src/util/logger.ts"],
+          testsRun: true,
+          commitMessageDraft: "refactor: logger",
+          prBodyDraft: "",
+        },
+        cwd: "/tmp/repo",
+      },
+      noopLogger as any
+    );
+
+    expect(capturedPrompt).toContain("README");
+    expect(capturedPrompt).toMatch(/no.*update|skip|unnecessary|not needed|do nothing/i);
+  });
+
+  it("uses only Read, Glob, Grep, Write, Edit tools", async () => {
+    let capturedOptions: Record<string, unknown> = {};
+    mockQuery.mockImplementation(({ options }: { prompt: string; options: Record<string, unknown> }) => {
+      capturedOptions = options;
+      return (async function* () {
+        yield { type: "result", subtype: "success", result: "" };
+      })();
+    });
+
+    await runDocumenter(
+      {
+        result: {
+          changeSummary: "test",
+          changedFiles: ["a.ts"],
+          testsRun: true,
+          commitMessageDraft: "test",
+          prBodyDraft: "",
+        },
+        cwd: "/tmp/repo",
+      },
+      noopLogger as any
+    );
+
+    expect(capturedOptions.allowedTools).toEqual([
+      "Read",
+      "Glob",
+      "Grep",
+      "Write",
+      "Edit",
+    ]);
+  });
+
+  it("sets maxTurns to 10", async () => {
+    let capturedOptions: Record<string, unknown> = {};
+    mockQuery.mockImplementation(({ options }: { prompt: string; options: Record<string, unknown> }) => {
+      capturedOptions = options;
+      return (async function* () {
+        yield { type: "result", subtype: "success", result: "" };
+      })();
+    });
+
+    await runDocumenter(
+      {
+        result: {
+          changeSummary: "test",
+          changedFiles: ["a.ts"],
+          testsRun: true,
+          commitMessageDraft: "test",
+          prBodyDraft: "",
+        },
+        cwd: "/tmp/repo",
+      },
+      noopLogger as any
+    );
+
+    expect(capturedOptions.maxTurns).toBe(10);
+  });
+});

--- a/test/workflow/states.test.ts
+++ b/test/workflow/states.test.ts
@@ -25,6 +25,7 @@ function makeCtx(overrides: Partial<RunContext> = {}): RunContext {
 function makeDeps(overrides?: {
   git?: Partial<GitAdapter>;
   github?: Partial<GitHubAdapter>;
+  runDocumenter?: Deps["runDocumenter"];
 }): Deps {
   const git: GitAdapter = {
     createBranch: vi.fn(async () => {}),
@@ -57,7 +58,8 @@ function makeDeps(overrides?: {
     warn: vi.fn(),
     error: vi.fn(),
   };
-  return { git, github, logger };
+  const runDocumenter = overrides?.runDocumenter ?? vi.fn(async () => {});
+  return { git, github, logger, runDocumenter };
 }
 
 describe("init handler", () => {
@@ -254,5 +256,83 @@ describe("watching_ci handler", () => {
       expect(getCiStatus).toHaveBeenCalledTimes(2);
       expect(result.nextState).toBe("fixing");
     });
+  });
+});
+
+describe("committing handler", () => {
+  const result = {
+    changeSummary: "Added feature X",
+    changedFiles: ["src/foo.ts"],
+    testsRun: true,
+    commitMessageDraft: "feat: add feature X",
+    prBodyDraft: "## Summary\nAdded feature X",
+  };
+
+  it("calls runDocumenter before git operations", async () => {
+    const callOrder: string[] = [];
+    const runDocumenter = vi.fn(async () => {
+      callOrder.push("documenter");
+    });
+    const deps = makeDeps({
+      git: {
+        addAll: vi.fn(async () => {
+          callOrder.push("addAll");
+        }),
+        commit: vi.fn(async () => {
+          callOrder.push("commit");
+        }),
+      },
+      runDocumenter,
+    });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({ state: "committing", result });
+
+    await handlers.committing!(ctx);
+
+    expect(callOrder).toEqual(["documenter", "addAll", "commit"]);
+  });
+
+  it("passes result and cwd to runDocumenter", async () => {
+    const runDocumenter = vi.fn(async () => {});
+    const deps = makeDeps({ runDocumenter });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({ state: "committing", result, cwd: "/my/repo" });
+
+    await handlers.committing!(ctx);
+
+    expect(runDocumenter).toHaveBeenCalledWith(
+      { result, cwd: "/my/repo" },
+      deps.logger
+    );
+  });
+
+  it("transitions to creating_pr after commit", async () => {
+    const deps = makeDeps();
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({ state: "committing", result });
+
+    const { nextState } = await handlers.committing!(ctx);
+
+    expect(nextState).toBe("creating_pr");
+  });
+
+  it("transitions to done when dryRun is true", async () => {
+    const deps = makeDeps();
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({ state: "committing", result, dryRun: true });
+
+    const { nextState } = await handlers.committing!(ctx);
+
+    expect(nextState).toBe("done");
+  });
+
+  it("throws when result is missing", async () => {
+    const deps = makeDeps();
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({ state: "committing" });
+
+    await expect(handlers.committing!(ctx)).rejects.toThrow(
+      "No result available"
+    );
   });
 });


### PR DESCRIPTION
## Summary

- committing フェーズで documenter エージェントを実行し、実装変更に応じて README 等のドキュメントを自動更新する
- ユーザー向け変更（CLI オプション、コマンド、ワークフロー）があればドキュメントを更新、内部リファクタのみなら何もしない
- `Deps` に `runDocumenter` を追加し、テストでモック可能な設計

## Test plan

- [x] documenter エージェントのプロンプト検証テスト（4 tests）
- [x] committing ハンドラの呼び出し順序・引数・遷移テスト（5 tests）
- [x] 全 106 テスト GREEN
- [x] `tsc --noEmit` コンパイルエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)