### PR TITLE
feat: isolate watch command issues with git worktrees to prevent concurrent git conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ node dist/index.js watch --repo <owner/name> --cwd <path>
 
 指定ラベル（デフォルト: `ai:run`）の Issue を定期的にポーリングし、見つかったら自動で開発ループを実行する。Issue に `auto-merge` ラベルがあれば CI 通過後に自動マージされる。
 
+各 Issue は `.worktrees/issue-<number>` に作成される git worktree 内で処理されるため、複数 Issue を並行して安全に処理できる。worktree は処理完了後に自動で削除される。`.worktrees/` を `.gitignore` に追加することを推奨する。
+
 | オプション | 説明 | デフォルト |
 |-----------|------|-----------|
 | `--label <label>` | 監視するラベル | `ai:run` |

--- a/src/adapters/git.ts
+++ b/src/adapters/git.ts
@@ -7,6 +7,8 @@ export interface GitAdapter {
   push(branch: string, cwd: string): Promise<void>;
   diff(base: string, cwd: string): Promise<string>;
   currentBranch(cwd: string): Promise<string>;
+  addWorktree(path: string, baseBranch: string, cwd: string): Promise<void>;
+  removeWorktree(path: string, cwd: string): Promise<void>;
 }
 
 export function createGitAdapter(): GitAdapter {
@@ -48,6 +50,14 @@ export function createGitAdapter(): GitAdapter {
         { cwd }
       );
       return stdout.trim();
+    },
+
+    async addWorktree(path, baseBranch, cwd) {
+      await execa("git", ["worktree", "add", path, baseBranch], { cwd });
+    },
+
+    async removeWorktree(path, cwd) {
+      await execa("git", ["worktree", "remove", "--force", path], { cwd });
     },
   };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -200,25 +200,41 @@ export function createCli() {
           });
 
           const runId = `run-${Date.now()}-${randomUUID().slice(0, 8)}`;
-          const ctx: RunContext = {
-            runId,
-            issueNumber: issue.number,
-            repo,
-            cwd,
-            state: "init",
-            branch: `aidev/issue-${issue.number}`,
-            maxFixAttempts: 3,
-            fixAttempts: 0,
-            dryRun: false,
-            autoMerge: false,
-            issueLabels: issue.labels,
+          const worktreePath = join(cwd, ".worktrees", `issue-${issue.number}`);
+
+          const runIssue = async () => {
+            await git.addWorktree(worktreePath, "main", cwd);
+            try {
+              const ctx: RunContext = {
+                runId,
+                issueNumber: issue.number,
+                repo,
+                cwd: worktreePath,
+                state: "init",
+                branch: `aidev/issue-${issue.number}`,
+                maxFixAttempts: 3,
+                fixAttempts: 0,
+                dryRun: false,
+                autoMerge: false,
+                issueLabels: issue.labels,
+              };
+
+              await runWorkflow(ctx, handlers, persistence, {
+                logger,
+                onTransition: (from, to) =>
+                  logger.info("State transition", { from, to }),
+              });
+            } finally {
+              await git.removeWorktree(worktreePath, cwd).catch((err) =>
+                logger.error("Worktree cleanup failed", {
+                  path: worktreePath,
+                  error: String(err),
+                })
+              );
+            }
           };
 
-          runWorkflow(ctx, handlers, persistence, {
-            logger,
-            onTransition: (from, to) =>
-              logger.info("State transition", { from, to }),
-          }).catch((err) =>
+          runIssue().catch((err) =>
             logger.error("Run failed", {
               issue: issue.number,
               error: String(err),

--- a/test/adapters/git.test.ts
+++ b/test/adapters/git.test.ts
@@ -100,4 +100,26 @@ describe("GitAdapter", () => {
       expect(branch).toBe("main");
     });
   });
+
+  describe("addWorktree", () => {
+    it("runs git worktree add with path and branch", async () => {
+      await git.addWorktree("/tmp/wt-42", "main", cwd);
+      expect(mockExeca).toHaveBeenCalledWith(
+        "git",
+        ["worktree", "add", "/tmp/wt-42", "main"],
+        { cwd }
+      );
+    });
+  });
+
+  describe("removeWorktree", () => {
+    it("runs git worktree remove --force with path", async () => {
+      await git.removeWorktree("/tmp/wt-42", cwd);
+      expect(mockExeca).toHaveBeenCalledWith(
+        "git",
+        ["worktree", "remove", "--force", "/tmp/wt-42"],
+        { cwd }
+      );
+    });
+  });
 });

--- a/test/cli-watch.test.ts
+++ b/test/cli-watch.test.ts
@@ -1,8 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock modules before any imports
+const mockAddWorktree = vi.fn(async () => {});
+const mockRemoveWorktree = vi.fn(async () => {});
+
 vi.mock("../src/adapters/git.js", () => ({
-  createGitAdapter: vi.fn(() => ({ checkout: vi.fn(), push: vi.fn() })),
+  createGitAdapter: vi.fn(() => ({
+    checkout: vi.fn(),
+    push: vi.fn(),
+    addWorktree: mockAddWorktree,
+    removeWorktree: mockRemoveWorktree,
+  })),
 }));
 
 vi.mock("../src/adapters/github.js", () => ({
@@ -230,5 +238,198 @@ describe("watch command", () => {
     expect(ctx1.branch).toBe("aidev/issue-10");
     expect(ctx2.issueNumber).toBe(20);
     expect(ctx2.branch).toBe("aidev/issue-20");
+  });
+
+  it("passes a unique worktree cwd to each issue's runWorkflow", async () => {
+    const mockGithub = {
+      listIssuesByLabel: vi.fn(async () => [
+        { number: 10, title: "Issue 10", body: "body", labels: ["ai:run"] },
+        { number: 20, title: "Issue 20", body: "body", labels: ["ai:run"] },
+      ]),
+      getIssue: vi.fn(),
+      commentOnIssue: vi.fn(),
+      createPr: vi.fn(),
+      getCiStatus: vi.fn(),
+      mergePr: vi.fn(),
+      closeIssue: vi.fn(),
+      getCheckRunLogs: vi.fn(),
+    };
+    vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
+
+    const mockRunWorkflow = vi.mocked(runWorkflow);
+    mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+      ...ctx,
+      state: "done",
+    }));
+
+    const originalSetInterval = global.setInterval;
+    vi.spyOn(global, "setInterval").mockImplementation(((
+      fn: Function,
+      ms: number
+    ) => {
+      return originalSetInterval(() => {}, ms);
+    }) as any);
+
+    const cli = createCli();
+    await cli.parseAsync([
+      "node",
+      "aidev",
+      "watch",
+      "--repo",
+      "owner/repo",
+      "--interval",
+      "999",
+    ]);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockRunWorkflow).toHaveBeenCalledTimes(2);
+
+    const ctx1 = mockRunWorkflow.mock.calls[0][0];
+    const ctx2 = mockRunWorkflow.mock.calls[1][0];
+
+    // Each issue should get a different cwd (worktree path)
+    expect(ctx1.cwd).not.toBe(ctx2.cwd);
+    expect(ctx1.cwd).toContain("worktree");
+    expect(ctx2.cwd).toContain("worktree");
+  });
+
+  it("cleans up worktree after successful runWorkflow", async () => {
+    const mockGithub = {
+      listIssuesByLabel: vi.fn(async () => [
+        { number: 42, title: "Test issue", body: "body", labels: ["ai:run"] },
+      ]),
+      getIssue: vi.fn(),
+      commentOnIssue: vi.fn(),
+      createPr: vi.fn(),
+      getCiStatus: vi.fn(),
+      mergePr: vi.fn(),
+      closeIssue: vi.fn(),
+      getCheckRunLogs: vi.fn(),
+    };
+    vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
+
+    const mockRunWorkflow = vi.mocked(runWorkflow);
+    mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+      ...ctx,
+      state: "done",
+    }));
+
+    const originalSetInterval = global.setInterval;
+    vi.spyOn(global, "setInterval").mockImplementation(((
+      fn: Function,
+      ms: number
+    ) => {
+      return originalSetInterval(() => {}, ms);
+    }) as any);
+
+    const cli = createCli();
+    await cli.parseAsync([
+      "node",
+      "aidev",
+      "watch",
+      "--repo",
+      "owner/repo",
+      "--interval",
+      "999",
+    ]);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockAddWorktree).toHaveBeenCalledTimes(1);
+    expect(mockRemoveWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up worktree after failed runWorkflow", async () => {
+    const mockGithub = {
+      listIssuesByLabel: vi.fn(async () => [
+        { number: 99, title: "Failing issue", body: "body", labels: ["ai:run"] },
+      ]),
+      getIssue: vi.fn(),
+      commentOnIssue: vi.fn(),
+      createPr: vi.fn(),
+      getCiStatus: vi.fn(),
+      mergePr: vi.fn(),
+      closeIssue: vi.fn(),
+      getCheckRunLogs: vi.fn(),
+    };
+    vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
+
+    const mockRunWorkflow = vi.mocked(runWorkflow);
+    mockRunWorkflow.mockRejectedValue(new Error("workflow failed"));
+
+    const originalSetInterval = global.setInterval;
+    vi.spyOn(global, "setInterval").mockImplementation(((
+      fn: Function,
+      ms: number
+    ) => {
+      return originalSetInterval(() => {}, ms);
+    }) as any);
+
+    const cli = createCli();
+    await cli.parseAsync([
+      "node",
+      "aidev",
+      "watch",
+      "--repo",
+      "owner/repo",
+      "--interval",
+      "999",
+    ]);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockAddWorktree).toHaveBeenCalledTimes(1);
+    // Worktree should still be cleaned up even on failure
+    expect(mockRemoveWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not crash when worktree creation fails", async () => {
+    const mockGithub = {
+      listIssuesByLabel: vi.fn(async () => [
+        { number: 55, title: "WT fail issue", body: "body", labels: ["ai:run"] },
+      ]),
+      getIssue: vi.fn(),
+      commentOnIssue: vi.fn(),
+      createPr: vi.fn(),
+      getCiStatus: vi.fn(),
+      mergePr: vi.fn(),
+      closeIssue: vi.fn(),
+      getCheckRunLogs: vi.fn(),
+    };
+    vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
+
+    mockAddWorktree.mockRejectedValueOnce(new Error("worktree add failed"));
+
+    const mockRunWorkflow = vi.mocked(runWorkflow);
+    mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+      ...ctx,
+      state: "done",
+    }));
+
+    const originalSetInterval = global.setInterval;
+    vi.spyOn(global, "setInterval").mockImplementation(((
+      fn: Function,
+      ms: number
+    ) => {
+      return originalSetInterval(() => {}, ms);
+    }) as any);
+
+    const cli = createCli();
+    // Should not throw
+    await cli.parseAsync([
+      "node",
+      "aidev",
+      "watch",
+      "--repo",
+      "owner/repo",
+      "--interval",
+      "999",
+    ]);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // runWorkflow should NOT have been called since worktree creation failed
+    expect(mockRunWorkflow).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Added `addWorktree` and `removeWorktree` methods to `GitAdapter` for managing git worktrees
- Modified the `watch` command to create a dedicated worktree per issue under `.worktrees/issue-<number>`, passing the worktree path as `cwd` to `runWorkflow`
- Added `finally` block to ensure worktree cleanup after workflow completion (success or failure), with error logging if cleanup fails
- Worktree creation failures are caught and logged without crashing the watcher

## Test plan
- [x] `GitAdapter.addWorktree` calls `git worktree add <path> <baseBranch>`
- [x] `GitAdapter.removeWorktree` calls `git worktree remove --force <path>`
- [x] Each issue in watch gets a unique worktree cwd
- [x] Worktree is cleaned up after successful workflow
- [x] Worktree is cleaned up after failed workflow
- [x] Watcher does not crash when worktree creation fails
- [x] All 112 tests pass, TypeScript compiles cleanly

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)