### PR TITLE
feat: add --base option to run/watch commands for specifying base branch/tag (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ node dist/index.js run --issue <number> --repo <owner/name> --cwd <path>
 | `--repo <owner/name>` | GitHub リポジトリ | 自動検出 |
 | `--cwd <path>` | 作業ディレクトリ | カレントディレクトリ |
 | `--auto-merge` | CI 通過後に自動マージ | `false` |
+| `--base <branch>` | ブランチ作成元のベースブランチまたはタグ | `main` |
 | `--dry-run` | push / PR 作成 / マージをスキップ | `false` |
 | `--resume` | 前回の実行を途中から再開 | — |
 | `--max-fix-attempts <n>` | CI 失敗時の最大修正回数 | `3` |
@@ -69,6 +70,7 @@ node dist/index.js watch --repo <owner/name> --cwd <path>
 |-----------|------|-----------|
 | `--label <label>` | 監視するラベル | `ai:run` |
 | `--interval <seconds>` | ポーリング間隔（秒） | `30` |
+| `--base <branch>` | worktree 作成元のベースブランチまたはタグ | `main` |
 | `--cwd <path>` | 作業ディレクトリ | カレントディレクトリ |
 | `--repo <owner/name>` | GitHub リポジトリ | 自動検出 |
 | `--claude-path <path>` | Claude Code バイナリのパス | PATH から自動検出 |

--- a/src/adapters/git.ts
+++ b/src/adapters/git.ts
@@ -1,7 +1,7 @@
 import { execa } from "execa";
 
 export interface GitAdapter {
-  createBranch(name: string, cwd: string): Promise<void>;
+  createBranch(name: string, base: string, cwd: string): Promise<void>;
   addAll(cwd: string): Promise<void>;
   commit(message: string, cwd: string): Promise<void>;
   push(branch: string, cwd: string): Promise<void>;
@@ -13,12 +13,12 @@ export interface GitAdapter {
 
 export function createGitAdapter(): GitAdapter {
   return {
-    async createBranch(name, cwd) {
+    async createBranch(name, base, cwd) {
       try {
-        await execa("git", ["checkout", "-b", name], { cwd });
+        await execa("git", ["checkout", "-b", name, base], { cwd });
       } catch {
-        // Branch already exists — reset it from main
-        await execa("git", ["checkout", "main"], { cwd });
+        // Branch already exists — reset it from base
+        await execa("git", ["checkout", base], { cwd });
         await execa("git", ["branch", "-D", name], { cwd });
         await execa("git", ["checkout", "-b", name], { cwd });
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,6 +92,7 @@ export function createCli() {
     .option("--max-fix-attempts <n>", "Max CI fix attempts", parseInt, 3)
     .option("--dry-run", "Skip push/PR/merge", false)
     .option("--auto-merge", "Merge PR and close issue after CI passes", false)
+    .option("--base <branch>", "Base branch or tag to create branch from", "main")
     .option("--repo <owner/name>", "GitHub repo (owner/name)")
     .option("--claude-path <path>", "Path to native Claude Code executable")
     .option("--resume", "Resume the latest run for this issue")
@@ -170,6 +171,7 @@ export function createCli() {
           cwd,
           state: "init",
           branch,
+          base: opts.base,
           maxFixAttempts: opts.maxFixAttempts,
           fixAttempts: 0,
           dryRun: opts.dryRun,
@@ -205,6 +207,7 @@ export function createCli() {
     .option("--label <label>", "Label to watch", "ai:run")
     .option("--interval <seconds>", "Poll interval in seconds", parseInt, 30)
     .option("--cwd <path>", "Working directory", process.cwd())
+    .option("--base <branch>", "Base branch or tag to create worktrees from", "main")
     .option("--repo <owner/name>", "GitHub repo (owner/name)")
     .option("--claude-path <path>", "Path to native Claude Code executable")
     .action(async (opts) => {
@@ -248,7 +251,7 @@ export function createCli() {
           const worktreePath = join(cwd, ".worktrees", `issue-${issue.number}`);
 
           const runIssue = async () => {
-            await git.addWorktree(worktreePath, "main", cwd);
+            await git.addWorktree(worktreePath, opts.base, cwd);
             try {
               const ctx: RunContext = {
                 runId,
@@ -257,6 +260,7 @@ export function createCli() {
                 cwd: worktreePath,
                 state: "init",
                 branch: `aidev/issue-${issue.number}`,
+                base: opts.base,
                 maxFixAttempts: 3,
                 fixAttempts: 0,
                 dryRun: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export const RunContextSchema = z.object({
   cwd: z.string(),
   state: RunStateSchema,
   branch: z.string(),
+  base: z.string().default("main"),
   maxFixAttempts: z.number().default(3),
   fixAttempts: z.number().default(0),
   dryRun: z.boolean(),

--- a/src/workflow/states.ts
+++ b/src/workflow/states.ts
@@ -47,7 +47,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
       }
     }
 
-    await git.createBranch(ctx.branch, ctx.cwd);
+    await git.createBranch(ctx.branch, ctx.base, ctx.cwd);
     logger.info("Created branch", { branch: ctx.branch });
     return transition(ctx, "planning", { issueLabels: issue.labels });
   };
@@ -85,7 +85,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
 
   const reviewing: StateHandler = async (ctx) => {
     if (!ctx.plan) throw new Error("No plan available");
-    const diff = await git.diff("main", ctx.cwd);
+    const diff = await git.diff(ctx.base, ctx.cwd);
     const reviewStart = performance.now();
     const review = await runReviewer(
       { plan: ctx.plan, diff, cwd: ctx.cwd },
@@ -122,7 +122,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
       title: ctx.result.commitMessageDraft.split("\n")[0]!,
       body: ctx.result.prBodyDraft,
       head: ctx.branch,
-      base: "main",
+      base: ctx.base,
     });
     logger.info("PR created", { prNumber });
     return transition(ctx, "watching_ci", { prNumber });

--- a/test/adapters/git.test.ts
+++ b/test/adapters/git.test.ts
@@ -20,29 +20,52 @@ describe("GitAdapter", () => {
 
   describe("createBranch", () => {
     it("creates new branch when it does not exist", async () => {
-      await git.createBranch("feature/x", cwd);
+      await git.createBranch("feature/x", "main", cwd);
       expect(mockExeca).toHaveBeenCalledWith(
         "git",
-        ["checkout", "-b", "feature/x"],
+        ["checkout", "-b", "feature/x", "main"],
         { cwd }
       );
     });
 
-    it("deletes existing branch then creates fresh one", async () => {
+    it("deletes existing branch then creates fresh one from base", async () => {
       const error = new Error("branch already exists");
       (error as any).exitCode = 128;
       mockExeca
         .mockRejectedValueOnce(error)       // checkout -b fails
-        .mockResolvedValueOnce({ stdout: "" } as any)  // checkout main
+        .mockResolvedValueOnce({ stdout: "" } as any)  // checkout base
         .mockResolvedValueOnce({ stdout: "" } as any)  // branch -D
         .mockResolvedValueOnce({ stdout: "" } as any); // checkout -b retry
 
-      await git.createBranch("feature/x", cwd);
+      await git.createBranch("feature/x", "main", cwd);
 
-      expect(mockExeca).toHaveBeenNthCalledWith(1, "git", ["checkout", "-b", "feature/x"], { cwd });
+      expect(mockExeca).toHaveBeenNthCalledWith(1, "git", ["checkout", "-b", "feature/x", "main"], { cwd });
       expect(mockExeca).toHaveBeenNthCalledWith(2, "git", ["checkout", "main"], { cwd });
       expect(mockExeca).toHaveBeenNthCalledWith(3, "git", ["branch", "-D", "feature/x"], { cwd });
       expect(mockExeca).toHaveBeenNthCalledWith(4, "git", ["checkout", "-b", "feature/x"], { cwd });
+    });
+
+    it("uses custom base for branch creation", async () => {
+      await git.createBranch("feature/x", "v1.2.0", cwd);
+      expect(mockExeca).toHaveBeenCalledWith(
+        "git",
+        ["checkout", "-b", "feature/x", "v1.2.0"],
+        { cwd }
+      );
+    });
+
+    it("falls back to custom base when branch already exists", async () => {
+      const error = new Error("branch already exists");
+      (error as any).exitCode = 128;
+      mockExeca
+        .mockRejectedValueOnce(error)
+        .mockResolvedValueOnce({ stdout: "" } as any)
+        .mockResolvedValueOnce({ stdout: "" } as any)
+        .mockResolvedValueOnce({ stdout: "" } as any);
+
+      await git.createBranch("feature/x", "release/1.3", cwd);
+
+      expect(mockExeca).toHaveBeenNthCalledWith(2, "git", ["checkout", "release/1.3"], { cwd });
     });
   });
 

--- a/test/cli-watch.test.ts
+++ b/test/cli-watch.test.ts
@@ -441,6 +441,114 @@ describe("watch command", () => {
     expect(mockRunWorkflow).not.toHaveBeenCalled();
   });
 
+  it("passes --base option to addWorktree and RunContext", async () => {
+    const mockGithub = {
+      listIssuesByLabel: vi.fn(async () => [
+        { number: 42, title: "Test issue", body: "body", labels: ["ai:run"], author: "testuser" },
+      ]),
+      getIssue: vi.fn(),
+      getAuthenticatedUser: vi.fn(async () => "testuser"),
+      commentOnIssue: vi.fn(),
+      createPr: vi.fn(),
+      getCiStatus: vi.fn(),
+      mergePr: vi.fn(),
+      closeIssue: vi.fn(),
+      getCheckRunLogs: vi.fn(),
+    };
+    vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
+
+    const mockRunWorkflow = vi.mocked(runWorkflow);
+    mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+      ...ctx,
+      state: "done",
+    }));
+
+    const originalSetInterval = global.setInterval;
+    vi.spyOn(global, "setInterval").mockImplementation(((
+      fn: Function,
+      ms: number
+    ) => {
+      return originalSetInterval(() => {}, ms);
+    }) as any);
+
+    const cli = createCli();
+    await cli.parseAsync([
+      "node",
+      "aidev",
+      "watch",
+      "--repo",
+      "owner/repo",
+      "--interval",
+      "999",
+      "--base",
+      "v1.2.0",
+    ]);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // addWorktree should be called with the custom base
+    expect(mockAddWorktree).toHaveBeenCalledTimes(1);
+    expect(mockAddWorktree.mock.calls[0][1]).toBe("v1.2.0");
+
+    // RunContext should include the custom base
+    expect(mockRunWorkflow).toHaveBeenCalledTimes(1);
+    const ctx = mockRunWorkflow.mock.calls[0][0];
+    expect(ctx.base).toBe("v1.2.0");
+  });
+
+  it("defaults base to 'main' when --base is not specified", async () => {
+    const mockGithub = {
+      listIssuesByLabel: vi.fn(async () => [
+        { number: 42, title: "Test issue", body: "body", labels: ["ai:run"], author: "testuser" },
+      ]),
+      getIssue: vi.fn(),
+      getAuthenticatedUser: vi.fn(async () => "testuser"),
+      commentOnIssue: vi.fn(),
+      createPr: vi.fn(),
+      getCiStatus: vi.fn(),
+      mergePr: vi.fn(),
+      closeIssue: vi.fn(),
+      getCheckRunLogs: vi.fn(),
+    };
+    vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
+
+    const mockRunWorkflow = vi.mocked(runWorkflow);
+    mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+      ...ctx,
+      state: "done",
+    }));
+
+    const originalSetInterval = global.setInterval;
+    vi.spyOn(global, "setInterval").mockImplementation(((
+      fn: Function,
+      ms: number
+    ) => {
+      return originalSetInterval(() => {}, ms);
+    }) as any);
+
+    const cli = createCli();
+    await cli.parseAsync([
+      "node",
+      "aidev",
+      "watch",
+      "--repo",
+      "owner/repo",
+      "--interval",
+      "999",
+    ]);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // addWorktree should be called with default "main"
+    expect(mockAddWorktree).toHaveBeenCalledTimes(1);
+    expect(mockAddWorktree.mock.calls[0][1]).toBe("main");
+
+    // RunContext should have default base "main"
+    expect(mockRunWorkflow).toHaveBeenCalledTimes(1);
+    const ctx = mockRunWorkflow.mock.calls[0][0];
+    expect(ctx.base).toBe("main");
+  });
+
   it("skips foreign issues with warning log in watch mode", async () => {
     const mockGithub = {
       listIssuesByLabel: vi.fn(async () => [
@@ -544,6 +652,94 @@ describe("run command", () => {
     expect(mockRunWorkflow).toHaveBeenCalledTimes(1);
     const ctx = mockRunWorkflow.mock.calls[0][0];
     expect(ctx.skipAuthorCheck).toBe(true);
+  });
+
+  it("passes --base option to RunContext", async () => {
+    const mockGithub = {
+      listIssuesByLabel: vi.fn(async () => []),
+      getIssue: vi.fn(async () => ({
+        number: 42,
+        title: "Test issue",
+        body: "body",
+        labels: [],
+        author: "testuser",
+      })),
+      getAuthenticatedUser: vi.fn(async () => "testuser"),
+      commentOnIssue: vi.fn(),
+      createPr: vi.fn(),
+      getCiStatus: vi.fn(),
+      mergePr: vi.fn(),
+      closeIssue: vi.fn(),
+      getCheckRunLogs: vi.fn(),
+    };
+    vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
+
+    const mockRunWorkflow = vi.mocked(runWorkflow);
+    mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+      ...ctx,
+      state: "done",
+    }));
+
+    const cli = createCli();
+    await cli.parseAsync([
+      "node",
+      "aidev",
+      "run",
+      "--issue",
+      "42",
+      "--repo",
+      "owner/repo",
+      "--yes",
+      "--base",
+      "v1.2.0",
+    ]);
+
+    expect(mockRunWorkflow).toHaveBeenCalledTimes(1);
+    const ctx = mockRunWorkflow.mock.calls[0][0];
+    expect(ctx.base).toBe("v1.2.0");
+  });
+
+  it("defaults base to 'main' when --base is not specified in run", async () => {
+    const mockGithub = {
+      listIssuesByLabel: vi.fn(async () => []),
+      getIssue: vi.fn(async () => ({
+        number: 42,
+        title: "Test issue",
+        body: "body",
+        labels: [],
+        author: "testuser",
+      })),
+      getAuthenticatedUser: vi.fn(async () => "testuser"),
+      commentOnIssue: vi.fn(),
+      createPr: vi.fn(),
+      getCiStatus: vi.fn(),
+      mergePr: vi.fn(),
+      closeIssue: vi.fn(),
+      getCheckRunLogs: vi.fn(),
+    };
+    vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
+
+    const mockRunWorkflow = vi.mocked(runWorkflow);
+    mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+      ...ctx,
+      state: "done",
+    }));
+
+    const cli = createCli();
+    await cli.parseAsync([
+      "node",
+      "aidev",
+      "run",
+      "--issue",
+      "42",
+      "--repo",
+      "owner/repo",
+      "--yes",
+    ]);
+
+    expect(mockRunWorkflow).toHaveBeenCalledTimes(1);
+    const ctx = mockRunWorkflow.mock.calls[0][0];
+    expect(ctx.base).toBe("main");
   });
 
   it("skips confirmation with --yes flag", async () => {

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -148,6 +148,7 @@ describe("RunContextSchema", () => {
     cwd: "/tmp/inko",
     state: "init",
     branch: "aidev/issue-42",
+    base: "main",
     maxFixAttempts: 3,
     fixAttempts: 0,
     dryRun: false,
@@ -205,6 +206,21 @@ describe("RunContextSchema", () => {
       issueLabels: ["auto-merge", "bug"],
     });
     expect(parsed.issueLabels).toEqual(["auto-merge", "bug"]);
+  });
+
+  it("defaults base to 'main'", () => {
+    const parsed = RunContextSchema.parse(validContext);
+    expect(parsed.base).toBe("main");
+  });
+
+  it("accepts custom base value", () => {
+    const parsed = RunContextSchema.parse({ ...validContext, base: "v1.2.0" });
+    expect(parsed.base).toBe("v1.2.0");
+  });
+
+  it("accepts branch-style base value", () => {
+    const parsed = RunContextSchema.parse({ ...validContext, base: "release/1.3" });
+    expect(parsed.base).toBe("release/1.3");
   });
 
   it("rejects context without issueNumber", () => {

--- a/test/workflow/states.test.ts
+++ b/test/workflow/states.test.ts
@@ -1,4 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../src/agents/reviewer.js", () => ({
+  runReviewer: vi.fn(async () => ({
+    decision: "approve",
+    mustFix: [],
+    summary: "Looks good",
+  })),
+}));
+
 import { createStateHandlers, type Deps } from "../../src/workflow/states.js";
 import type { RunContext } from "../../src/types.js";
 import type { GitAdapter } from "../../src/adapters/git.js";
@@ -18,6 +27,7 @@ function makeCtx(overrides: Partial<RunContext> = {}): RunContext {
     dryRun: false,
     autoMerge: false,
     issueLabels: [],
+    base: "main",
     ...overrides,
   };
 }
@@ -134,6 +144,34 @@ describe("init handler", () => {
     const result = await handlers.init!(ctx);
 
     expect(result.nextState).toBe("planning");
+  });
+
+  it("passes ctx.base to git.createBranch", async () => {
+    const deps = makeDeps();
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({ base: "v1.2.0" });
+
+    await handlers.init!(ctx);
+
+    expect(deps.git.createBranch).toHaveBeenCalledWith(
+      ctx.branch,
+      "v1.2.0",
+      ctx.cwd
+    );
+  });
+
+  it("passes default base 'main' to git.createBranch", async () => {
+    const deps = makeDeps();
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx();
+
+    await handlers.init!(ctx);
+
+    expect(deps.git.createBranch).toHaveBeenCalledWith(
+      ctx.branch,
+      "main",
+      ctx.cwd
+    );
   });
 
   it("skips author check when skipAuthorCheck is true", async () => {
@@ -399,6 +437,94 @@ describe("committing handler", () => {
 
     await expect(handlers.committing!(ctx)).rejects.toThrow(
       "No result available"
+    );
+  });
+});
+
+describe("reviewing handler", () => {
+  it("passes ctx.base to git.diff instead of hardcoded 'main'", async () => {
+    const diff = vi.fn(async () => "some diff");
+    const deps = makeDeps({ git: { diff } });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      state: "reviewing",
+      base: "v1.2.0",
+      plan: {
+        summary: "Do X",
+        steps: ["Step 1"],
+        filesToTouch: ["a.ts"],
+        tests: ["a.test.ts"],
+        risks: [],
+        acceptanceCriteria: ["X done"],
+      },
+    });
+
+    await handlers.reviewing!(ctx);
+
+    expect(diff).toHaveBeenCalledWith("v1.2.0", ctx.cwd);
+  });
+
+  it("uses default base 'main' for git.diff when base is not customized", async () => {
+    const diff = vi.fn(async () => "some diff");
+    const deps = makeDeps({ git: { diff } });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      state: "reviewing",
+      plan: {
+        summary: "Do X",
+        steps: ["Step 1"],
+        filesToTouch: ["a.ts"],
+        tests: ["a.test.ts"],
+        risks: [],
+        acceptanceCriteria: ["X done"],
+      },
+    });
+
+    await handlers.reviewing!(ctx);
+
+    expect(diff).toHaveBeenCalledWith("main", ctx.cwd);
+  });
+});
+
+describe("creating_pr handler", () => {
+  const result = {
+    changeSummary: "Added feature X",
+    changedFiles: ["src/foo.ts"],
+    testsRun: true,
+    commitMessageDraft: "feat: add feature X",
+    prBodyDraft: "## Summary\nAdded feature X",
+  };
+
+  it("passes ctx.base as PR base instead of hardcoded 'main'", async () => {
+    const createPr = vi.fn(async () => 42);
+    const deps = makeDeps({ github: { createPr } });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      state: "creating_pr",
+      base: "release/1.3",
+      result,
+    });
+
+    await handlers.creating_pr!(ctx);
+
+    expect(createPr).toHaveBeenCalledWith(
+      expect.objectContaining({ base: "release/1.3" })
+    );
+  });
+
+  it("uses default base 'main' for PR when base is not customized", async () => {
+    const createPr = vi.fn(async () => 42);
+    const deps = makeDeps({ github: { createPr } });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      state: "creating_pr",
+      result,
+    });
+
+    await handlers.creating_pr!(ctx);
+
+    expect(createPr).toHaveBeenCalledWith(
+      expect.objectContaining({ base: "main" })
     );
   });
 });


### PR DESCRIPTION
## 概要
run/watch コマンドにハードコードされていた `main` ベースブランチの代わりに、任意のブランチやタグを指定できる `--base` オプションを追加。

## 変更内容
- `RunContextSchema` に `base` フィールドを追加（デフォルト: `"main"`、Zod `.default()` により後方互換性を維持）
- `GitAdapter.createBranch` のシグネチャに `base` パラメータを追加し、フォールバック時も指定された base を使用するよう変更
- `init` ステートハンドラで `ctx.base` を `git.createBranch` に渡すよう変更
- `reviewing` ステートハンドラで `git.diff` にハードコードの `"main"` の代わりに `ctx.base` を使用
- `creating_pr` ステートハンドラで PR のベースブランチに `ctx.base` を使用
- `run` コマンドに `--base <branch>` オプションを追加（デフォルト: `"main"`）
- `watch` コマンドに `--base <branch>` オプションを追加し、worktree 作成と RunContext に反映

## テスト
- [x] 既存テストがパスすることを確認
- [x] 必要に応じて新規テストを追加
  - `test/types.test.ts`: `base` フィールドのデフォルト値・カスタム値テスト
  - `test/workflow/states.test.ts`: `init`, `reviewing`, `creating_pr` ハンドラでの `ctx.base` 伝播テスト
  - `test/cli-watch.test.ts`: `--base` オプションの watch/run コマンドでの受け渡しテスト
  - `test/adapters/git.test.ts`: `createBranch` のカスタム base 対応テスト

## 関連 Issue
closes #39