### PR TITLE
feat: add human-readable output for status command with --json flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ node dist/index.js watch --repo <owner/name> --cwd <path>
 node dist/index.js status <run-id>
 ```
 
+デフォルトでは人間が読みやすい整形済みテキストで出力される。`--json` を指定すると生の JSON を出力する。
+
+| オプション | 説明 | デフォルト |
+|-----------|------|-----------|
+| `--json` | JSON 形式で出力 | `false` |
+
 ## ワークフロー
 
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { runDocumenter } from "./agents/documenter.js";
 import { createSlackNotifier, formatSlackMessage } from "./adapters/slack.js";
 import { loadRepoConfig } from "./config/repo-config.js";
 import { writeAidevYml } from "./config/init.js";
+import { formatStatus } from "./util/format-status.js";
 import type { RunContext } from "./types.js";
 
 function createFilePersistence(baseDir: string): Persistence {
@@ -370,7 +371,8 @@ export function createCli() {
     .command("status")
     .description("Show status of a run")
     .argument("<run-id>", "Run ID")
-    .action(async (runId) => {
+    .option("--json", "Output raw JSON", false)
+    .action(async (runId, opts) => {
       const baseDir = join(
         process.env.HOME ?? "~",
         ".devloop",
@@ -382,7 +384,11 @@ export function createCli() {
         console.error(`Run not found: ${runId}`);
         process.exit(1);
       }
-      console.log(JSON.stringify(ctx, null, 2));
+      if (opts.json) {
+        console.log(JSON.stringify(ctx, null, 2));
+      } else {
+        console.log(formatStatus(ctx));
+      }
     });
 
   return program;

--- a/src/util/format-status.ts
+++ b/src/util/format-status.ts
@@ -1,0 +1,43 @@
+import type { RunContext } from "../types.js";
+
+export function formatStatus(ctx: RunContext): string {
+  const lines: string[] = [];
+
+  lines.push(fmt("State", ctx.state));
+  lines.push(fmt("Run ID", ctx.runId));
+
+  const issue = ctx.issueTitle
+    ? `#${ctx.issueNumber} - ${ctx.issueTitle}`
+    : `#${ctx.issueNumber}`;
+  lines.push(fmt("Issue", issue));
+
+  lines.push(fmt("Repo", ctx.repo));
+  lines.push(fmt("Branch", ctx.branch));
+  lines.push(fmt("Base", ctx.base));
+
+  if (ctx.prNumber != null) {
+    lines.push(fmt("PR", `#${ctx.prNumber}`));
+  }
+
+  if (ctx.review) {
+    lines.push(fmt("Review", ctx.review.decision));
+  }
+
+  if (ctx.state === "fixing" || ctx.fixAttempts > 0) {
+    lines.push(fmt("Fix Attempts", `${ctx.fixAttempts}/${ctx.maxFixAttempts}`));
+  }
+
+  if (ctx.dryRun) {
+    lines.push(fmt("Dry Run", "true"));
+  }
+
+  if (ctx.autoMerge) {
+    lines.push(fmt("Auto Merge", "true"));
+  }
+
+  return lines.join("\n");
+}
+
+function fmt(label: string, value: string): string {
+  return `${(label + ":").padEnd(14)}${value}`;
+}

--- a/test/format-status.test.ts
+++ b/test/format-status.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { formatStatus } from "../src/util/format-status.js";
+import type { RunContext } from "../src/types.js";
+
+function makeCtx(overrides: Partial<RunContext> = {}): RunContext {
+  return {
+    runId: "abc-123",
+    issueNumber: 42,
+    repo: "owner/repo",
+    cwd: "/tmp/work",
+    state: "implementing",
+    branch: "feat/my-feature",
+    base: "main",
+    maxFixAttempts: 3,
+    fixAttempts: 0,
+    dryRun: false,
+    autoMerge: false,
+    issueLabels: [],
+    skipAuthorCheck: false,
+    skipStates: [],
+    ...overrides,
+  };
+}
+
+describe("formatStatus", () => {
+  it("returns state, issue number, branch, repo for minimal context", () => {
+    const out = formatStatus(makeCtx());
+    expect(out).toContain("State:        implementing");
+    expect(out).toContain("Run ID:       abc-123");
+    expect(out).toContain("Issue:        #42");
+    expect(out).toContain("Repo:         owner/repo");
+    expect(out).toContain("Branch:       feat/my-feature");
+    expect(out).toContain("Base:         main");
+  });
+
+  it("includes prNumber when present", () => {
+    const out = formatStatus(makeCtx({ prNumber: 99 }));
+    expect(out).toContain("PR:           #99");
+  });
+
+  it("does not include PR line when prNumber is absent", () => {
+    const out = formatStatus(makeCtx());
+    expect(out).not.toContain("PR:");
+  });
+
+  it("includes issueTitle when present", () => {
+    const out = formatStatus(makeCtx({ issueTitle: "Add dark mode" }));
+    expect(out).toContain("Issue:        #42 - Add dark mode");
+  });
+
+  it("shows review decision when review exists", () => {
+    const out = formatStatus(
+      makeCtx({
+        review: {
+          decision: "changes_requested",
+          mustFix: ["fix the bug"],
+          summary: "needs work",
+        },
+      })
+    );
+    expect(out).toContain("Review:       changes_requested");
+  });
+
+  it("shows fixAttempts/maxFixAttempts when in fixing state", () => {
+    const out = formatStatus(
+      makeCtx({ state: "fixing", fixAttempts: 1, maxFixAttempts: 3 })
+    );
+    expect(out).toContain("Fix Attempts: 1/3");
+  });
+
+  it("shows fixAttempts/maxFixAttempts when fixAttempts > 0", () => {
+    const out = formatStatus(
+      makeCtx({ state: "done", fixAttempts: 2, maxFixAttempts: 3 })
+    );
+    expect(out).toContain("Fix Attempts: 2/3");
+  });
+
+  it("does not show fixAttempts when 0 and not in fixing state", () => {
+    const out = formatStatus(makeCtx({ state: "done", fixAttempts: 0 }));
+    expect(out).not.toContain("Fix Attempts:");
+  });
+
+  it("shows dryRun when true", () => {
+    const out = formatStatus(makeCtx({ dryRun: true }));
+    expect(out).toContain("Dry Run:      true");
+  });
+
+  it("shows autoMerge when true", () => {
+    const out = formatStatus(makeCtx({ autoMerge: true }));
+    expect(out).toContain("Auto Merge:   true");
+  });
+
+  it("does not show dryRun/autoMerge when false", () => {
+    const out = formatStatus(makeCtx({ dryRun: false, autoMerge: false }));
+    expect(out).not.toContain("Dry Run:");
+    expect(out).not.toContain("Auto Merge:");
+  });
+});


### PR DESCRIPTION
## 概要
`aidev status` コマンドの出力をデフォルトで人間が読みやすいフォーマットに変更し、`--json` フラグで従来の JSON 出力を維持する。

## 変更内容
- `src/util/format-status.ts` を新規作成: `formatStatus()` 関数で RunContext の主要フィールド（state, runId, issue, repo, branch, base, PR, review, fix attempts, dryRun, autoMerge）を整列された複数行テキストにフォーマット
- `src/cli.ts` の status コマンドに `--json` オプションを追加し、デフォルトは `formatStatus()` による人間可読出力、`--json` 指定時は従来の `JSON.stringify` 出力に切り替え
- `test/format-status.test.ts` を新規作成: formatStatus 関数の 11 件のユニットテスト

## テスト
- [x] 既存テストがパスすることを確認（247 tests, 17 files all pass）
- [x] 必要に応じて新規テストを追加（11 tests in test/format-status.test.ts）

## 関連 Issue
closes #46