### PR TITLE
feat: add aidev npm script and update README usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ bun run build
 ### `run` — Issue を処理する
 
 ```bash
-node dist/index.js run --issue <number> --repo <owner/name> --cwd <path>
+bun run aidev run --issue <number> --repo <owner/name> --cwd <path>
 ```
 
 | オプション | 説明 | デフォルト |
@@ -88,7 +88,7 @@ skip:
 ### `watch` — ラベル付き Issue を監視して自動処理
 
 ```bash
-node dist/index.js watch --repo <owner/name> --cwd <path>
+bun run aidev watch --repo <owner/name> --cwd <path>
 ```
 
 指定ラベル（デフォルト: `ai:run`）の Issue を定期的にポーリングし、見つかったら自動で開発ループを実行する。Issue に `auto-merge` ラベルがあれば CI 通過後に自動マージされる。
@@ -109,7 +109,7 @@ node dist/index.js watch --repo <owner/name> --cwd <path>
 ### `status` — 実行状態を確認
 
 ```bash
-node dist/index.js status <run-id>
+bun run aidev status <run-id>
 ```
 
 ## ワークフロー

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "aidev": "./dist/index.js"
   },
   "scripts": {
+    "aidev": "node dist/index.js",
     "build": "tsc",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## 概要
package.json に `aidev` スクリプトエントリを追加し、README のコマンド例を `bun run aidev` に統一する。

## 変更内容
- `package.json` の `scripts` に `"aidev": "node dist/index.js"` を追加
- `README.md` の `run`, `watch`, `status` コマンド例を `node dist/index.js` から `bun run aidev` に変更（3箇所）

## テスト
- [x] 既存テストがパスすることを確認（209 tests passed）
- [x] `bun run aidev -- --help` でスクリプトエントリの動作を確認
- [x] `bun run aidev run --help` でサブコマンドの引数パススルーを確認
- [x] `bun run build` が正常に完了することを確認

## 関連 Issue
closes #49