### PR TITLE
feat: add MIT license, .env to gitignore, and license field to package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .devloop/
+.env

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Satoshi Mizumura
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "aidev",
   "version": "0.0.1",
+  "license": "MIT",
   "type": "module",
   "bin": {
     "aidev": "./dist/index.js"

--- a/test/project-setup.test.ts
+++ b/test/project-setup.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+
+describe("LICENSE file", () => {
+  const license = readFileSync(resolve(root, "LICENSE"), "utf-8");
+
+  it("contains MIT License text", () => {
+    expect(license).toContain("MIT License");
+  });
+
+  it("contains correct copyright holder", () => {
+    expect(license).toContain("Satoshi Mizumura");
+  });
+
+  it("contains correct year", () => {
+    expect(license).toContain("2026");
+  });
+});
+
+describe(".gitignore", () => {
+  const gitignore = readFileSync(resolve(root, ".gitignore"), "utf-8");
+
+  it("contains .env entry", () => {
+    const lines = gitignore.split("\n").map((l) => l.trim());
+    expect(lines).toContain(".env");
+  });
+});
+
+describe("package.json", () => {
+  const pkg = JSON.parse(
+    readFileSync(resolve(root, "package.json"), "utf-8")
+  );
+
+  it('has license field set to "MIT"', () => {
+    expect(pkg.license).toBe("MIT");
+  });
+});


### PR DESCRIPTION
## 概要
公開リリース準備として、MIT ライセンスの追加、.env のセキュリティ対策、package.json のライセンスフィールド追加を行う。

## 変更内容
- MIT License ファイルを新規作成（Copyright (c) 2026 Satoshi Mizumura）
- `.gitignore` に `.env` エントリを追加（将来の環境変数ファイル誤コミット防止）
- `package.json` に `"license": "MIT"` フィールドを追加
- 上記3点を検証するテストを `test/project-setup.test.ts` に追加

## テスト
- [x] 既存テストがパスすることを確認（214 tests passed）
- [x] 新規テスト5件を追加（LICENSE内容、.gitignore内容、package.jsonライセンスフィールド）

## 関連 Issue
closes #51