### PR TITLE
fix: サブスクリプション認証を使用するよう修正

### DIFF
--- a/src/agents/shared.ts
+++ b/src/agents/shared.ts
@@ -65,14 +65,19 @@ export function createSafetyHook(): HookCallbackMatcher {
   return { hooks: [hook] };
 }
 
-/** 入れ子判定を回避するために削除する環境変数 */
-const NESTED_DETECTION_VARS = ["CLAUDECODE"];
+/**
+ * SDK サブプロセスから除外する環境変数:
+ * - CLAUDECODE: 入れ子判定を回避
+ * - ANTHROPIC_API_KEY: API Key 認証（クレジット制）ではなく
+ *   サブスクリプション認証（claude login セッション）を使うため除外
+ */
+const EXCLUDED_ENV_VARS = ["CLAUDECODE", "ANTHROPIC_API_KEY"];
 
 export function cleanEnvForSdk(): Record<string, string> {
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
     if (value === undefined) continue;
-    if (NESTED_DETECTION_VARS.includes(key)) continue;
+    if (EXCLUDED_ENV_VARS.includes(key)) continue;
     env[key] = value;
   }
   // SDK として起動することを明示

--- a/test/agents/shared.test.ts
+++ b/test/agents/shared.test.ts
@@ -290,10 +290,10 @@ describe("cleanEnvForSdk", () => {
     });
   });
 
-  it("preserves ANTHROPIC_API_KEY", () => {
+  it("excludes ANTHROPIC_API_KEY to use subscription auth", () => {
     withEnv({ ANTHROPIC_API_KEY: "sk-test-key" }, () => {
       const env = cleanEnvForSdk();
-      expect(env.ANTHROPIC_API_KEY).toBe("sk-test-key");
+      expect(env.ANTHROPIC_API_KEY).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## 概要
SDK サブプロセスが ANTHROPIC_API_KEY を継承することで API Key 認証（クレジット制）を使い、"Credit balance is too low" エラーが発生する問題を修正。

## 原因
`cleanEnvForSdk()` が `ANTHROPIC_API_KEY` をサブプロセスに渡していたため、`claude login` のサブスクリプション認証ではなくクレジットベースの認証が使われていた。

## 変更内容
- `cleanEnvForSdk()` から `ANTHROPIC_API_KEY` を除外
- サブプロセスは `claude login` のセッショントークンで認証
- テストを更新（preserve → exclude）

## テスト
- [x] 全 241 テスト通過