### PR TITLE
feat: log planner progress events (#62)

### DIFF
--- a/src/agents/planner.ts
+++ b/src/agents/planner.ts
@@ -1,6 +1,12 @@
 import { query, type SDKMessage } from "@anthropic-ai/claude-code";
 import { PlanSchema, type Plan } from "../types.js";
-import { createSafetyHook, extractJson, getBaseSdkOptions, wrapUntrustedContent } from "./shared.js";
+import {
+  createSafetyHook,
+  extractJson,
+  getBaseSdkOptions,
+  logAgentProgress,
+  wrapUntrustedContent,
+} from "./shared.js";
 import type { Issue } from "../adapters/github.js";
 import type { Logger } from "../util/logger.js";
 
@@ -49,6 +55,7 @@ Your final message must contain ONLY the JSON object, nothing else.`;
 
   let resultText = "";
   for await (const message of response) {
+    logAgentProgress(logger, "Planner", message as SDKMessage);
     if (message.type === "result" && message.subtype === "success") {
       resultText = message.result;
     }

--- a/src/agents/shared.ts
+++ b/src/agents/shared.ts
@@ -4,8 +4,10 @@ import type {
   HookCallback,
   HookCallbackMatcher,
   Options,
+  SDKMessage,
   SyncHookJSONOutput,
 } from "@anthropic-ai/claude-code";
+import type { Logger } from "../util/logger.js";
 
 const DANGEROUS_BASH_PATTERNS = [
   /\bgit\s+push\b/,
@@ -131,4 +133,45 @@ export function getBaseSdkOptions(): Pick<Options, "pathToClaudeCodeExecutable" 
     pathToClaudeCodeExecutable: executable,
     env: cleanEnvForSdk(),
   };
+}
+
+function getRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+export function logAgentProgress(
+  logger: Logger,
+  agentName: string,
+  message: SDKMessage
+): void {
+  if (message.type === "result") {
+    return;
+  }
+
+  const payload: Record<string, unknown> = {
+    eventType: message.type,
+  };
+
+  const subtype = getRecord(message)?.subtype;
+  if (typeof subtype === "string") {
+    payload.subtype = subtype;
+  }
+
+  const directName = getRecord(message)?.name;
+  if (typeof directName === "string") {
+    payload.toolName = directName;
+  }
+
+  const nestedMessage = getRecord(getRecord(message)?.message);
+  if (typeof nestedMessage?.id === "string") {
+    payload.messageId = nestedMessage.id;
+  }
+  if (typeof nestedMessage?.model === "string") {
+    payload.model = nestedMessage.model;
+  }
+
+  logger.info(`${agentName} progress`, payload);
 }

--- a/test/agents/planner.test.ts
+++ b/test/agents/planner.test.ts
@@ -60,6 +60,59 @@ describe("runPlanner prompt", () => {
     vi.clearAllMocks();
   });
 
+  it("logs compact progress events before planner success", async () => {
+    mockQuery.mockImplementation(() =>
+      (async function* () {
+        yield {
+          type: "assistant",
+          message: {
+            id: "msg_1",
+            model: "claude-test",
+          },
+        };
+        yield {
+          type: "tool_use",
+          name: "Read",
+        };
+        yield {
+          type: "result",
+          subtype: "success",
+          result: "{}",
+        };
+      })()
+    );
+
+    mockExtractJson.mockReturnValue({
+      summary: "s",
+      steps: ["a"],
+      filesToTouch: [],
+      tests: [],
+      risks: [],
+      acceptanceCriteria: [],
+      investigation: "test",
+    });
+
+    await runPlanner(
+      { issue: { number: 1, title: "Test", body: "body", labels: [] }, cwd: "/tmp" },
+      noopLogger as any
+    );
+
+    expect(noopLogger.info).toHaveBeenCalledWith(
+      "Planner progress",
+      expect.objectContaining({
+        eventType: "assistant",
+        messageId: "msg_1",
+      })
+    );
+    expect(noopLogger.info).toHaveBeenCalledWith(
+      "Planner progress",
+      expect.objectContaining({
+        eventType: "tool_use",
+        toolName: "Read",
+      })
+    );
+  });
+
   it("includes investigation format instructions for markdown lists and inline code", async () => {
     const getPrompt = setupMocks();
 


### PR DESCRIPTION
## Summary
- add compact planner progress logging for non-result Claude SDK events
- keep payloads structured and small for operator visibility
- add regression coverage for planner progress logging

## Testing
- /Users/tomo/clawd/projects/odysseus/aidev/node_modules/.bin/vitest run test/agents/planner.test.ts test/agents/shared.test.ts
- /Users/tomo/clawd/projects/odysseus/aidev/node_modules/.bin/vitest run
- bun run build

Closes #62