### PR TITLE
feat: add tool usage details and elapsed time to agent execution logs (#83)

### DIFF
--- a/src/agents/shared.ts
+++ b/src/agents/shared.ts
@@ -203,6 +203,57 @@ export function getBaseSdkOptions(): Pick<Options, "pathToClaudeCodeExecutable" 
   };
 }
 
+const COMMAND_TRUNCATE_LENGTH = 120;
+
+export function extractToolDetail(
+  toolName: string,
+  input: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  if (!input) return {};
+
+  if (toolName === "Read" || toolName === "Edit" || toolName === "Write") {
+    const filePath = input.file_path;
+    if (typeof filePath === "string") {
+      const isSensitive = SECRET_FILE_PATTERNS.some((p) => p.test(filePath));
+      return { file_path: isSensitive ? "[REDACTED]" : filePath };
+    }
+    return {};
+  }
+
+  if (toolName === "Bash") {
+    const command = input.command;
+    if (typeof command === "string") {
+      const truncated =
+        command.length > COMMAND_TRUNCATE_LENGTH
+          ? command.slice(0, COMMAND_TRUNCATE_LENGTH) + "..."
+          : command;
+      return { command: truncated };
+    }
+    return {};
+  }
+
+  if (toolName === "Glob" || toolName === "Grep") {
+    const pattern = input.pattern;
+    if (typeof pattern === "string") {
+      return { pattern };
+    }
+    return {};
+  }
+
+  return {};
+}
+
+export function formatElapsed(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) return `${hours}h${minutes}m${seconds}s`;
+  if (minutes > 0) return `${minutes}m${seconds}s`;
+  return `${seconds}s`;
+}
+
 function getRecord(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return undefined;
@@ -233,11 +284,18 @@ export function formatProgressEvent(
   const toolName = rec?.name;
   if (typeof toolName === "string") {
     payload.tool = toolName;
+
+    const input = getRecord(rec?.input);
+    const detail = extractToolDetail(toolName, input);
+    if (Object.keys(detail).length > 0) {
+      payload.toolDetail = detail;
+    }
   }
 
   // Support synthetic state_transition events
   if (typeof rec?.from === "string") payload.from = rec.from;
   if (typeof rec?.to === "string") payload.to = rec.to;
+  if (typeof rec?.elapsed === "string") payload.elapsed = rec.elapsed;
 
   return JSON.stringify(payload);
 }
@@ -260,9 +318,16 @@ export function logAgentProgress(
     payload.subtype = subtype;
   }
 
-  const directName = getRecord(message)?.name;
+  const rec = getRecord(message);
+  const directName = rec?.name;
   if (typeof directName === "string") {
     payload.toolName = directName;
+
+    const input = getRecord(rec?.input);
+    const detail = extractToolDetail(directName, input);
+    if (Object.keys(detail).length > 0) {
+      payload.toolDetail = detail;
+    }
   }
 
   const nestedMessage = getRecord(getRecord(message)?.message);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ import { loadRepoConfig } from "./config/repo-config.js";
 import { writeAidevYml } from "./config/init.js";
 import { runPreflightChecks } from "./preflight.js";
 import type { RunContext } from "./types.js";
-import { formatProgressEvent } from "./agents/shared.js";
+import { formatElapsed, formatProgressEvent } from "./agents/shared.js";
 
 function createFilePersistence(baseDir: string): Persistence {
   return {
@@ -276,14 +276,16 @@ export function createCli() {
       try {
         const result = await runWorkflow(ctx, handlers, persistence, {
           logger,
-          onTransition: (from, to) => {
+          onTransition: (from, to, elapsedMs) => {
             lastKnownState = to;
-            logger.info("State transition", { from, to });
+            const elapsed = elapsedMs != null ? formatElapsed(elapsedMs) : undefined;
+            logger.info("State transition", { from, to, ...(elapsed ? { elapsed } : {}) });
             if (verbose) {
               const line = formatProgressEvent("Workflow", {
                 type: "state_transition" as any,
                 from,
                 to,
+                ...(elapsed ? { elapsed } : {}),
               } as any);
               if (line) process.stderr.write(line + "\n");
             }

--- a/src/workflow/engine.ts
+++ b/src/workflow/engine.ts
@@ -11,7 +11,7 @@ export interface Persistence {
 }
 
 export interface WorkflowOptions {
-  onTransition?: (from: RunState, to: RunState) => void;
+  onTransition?: (from: RunState, to: RunState, elapsedMs?: number) => void;
   onComplete?: (ctx: RunContext) => Promise<void>;
   logger?: Logger;
 }
@@ -40,7 +40,7 @@ export async function runWorkflow(
     const elapsedMs = Math.round(performance.now() - handlerStart);
 
     logger?.info(`State ${from} completed`, { state: from, elapsedMs });
-    options?.onTransition?.(from, nextState);
+    options?.onTransition?.(from, nextState, elapsedMs);
 
     ctx = { ...nextCtx, state: nextState };
     await persistence.save(ctx);

--- a/test/agents/shared-progress.test.ts
+++ b/test/agents/shared-progress.test.ts
@@ -84,4 +84,30 @@ describe("formatProgressEvent", () => {
     expect(parsed.from).toBe("planning");
     expect(parsed.to).toBe("implementing");
   });
+
+  it("includes tool details for tool_use with input", () => {
+    const result = formatProgressEvent("Implementer", {
+      type: "tool_use",
+      name: "Read",
+      input: { file_path: "/src/main.ts" },
+    } as any);
+
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!);
+    expect(parsed.tool).toBe("Read");
+    expect(parsed.toolDetail).toEqual({ file_path: "/src/main.ts" });
+  });
+
+  it("includes elapsed in state_transition when provided", () => {
+    const result = formatProgressEvent("Workflow", {
+      type: "state_transition" as any,
+      from: "planning",
+      to: "implementing",
+      elapsed: "2m20s",
+    } as any);
+
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!);
+    expect(parsed.elapsed).toBe("2m20s");
+  });
 });

--- a/test/agents/shared.test.ts
+++ b/test/agents/shared.test.ts
@@ -3,6 +3,8 @@ import {
   blockDangerousOps,
   cleanEnvForSdk,
   extractJson,
+  extractToolDetail,
+  formatElapsed,
   getBaseSdkOptions,
   findClaudeExecutable,
   logAgentProgress,
@@ -408,6 +410,55 @@ describe("logAgentProgress", () => {
       eventType: "system",
     });
   });
+
+  it("includes toolDetail with file_path for Read tool_use with input", () => {
+    logAgentProgress(logger as any, "Implementer", {
+      type: "tool_use",
+      name: "Read",
+      input: { file_path: "/src/main.ts" },
+    } as any);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "Implementer progress",
+      expect.objectContaining({
+        eventType: "tool_use",
+        toolName: "Read",
+        toolDetail: { file_path: "/src/main.ts" },
+      })
+    );
+  });
+
+  it("includes toolDetail with command for Bash tool_use with input", () => {
+    logAgentProgress(logger as any, "Implementer", {
+      type: "tool_use",
+      name: "Bash",
+      input: { command: "npm test" },
+    } as any);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "Implementer progress",
+      expect.objectContaining({
+        eventType: "tool_use",
+        toolName: "Bash",
+        toolDetail: { command: "npm test" },
+      })
+    );
+  });
+
+  it("redacts sensitive file paths in toolDetail", () => {
+    logAgentProgress(logger as any, "Implementer", {
+      type: "tool_use",
+      name: "Read",
+      input: { file_path: "/home/user/.env" },
+    } as any);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "Implementer progress",
+      expect.objectContaining({
+        toolDetail: { file_path: "[REDACTED]" },
+      })
+    );
+  });
 });
 
 describe("streamAgentResponse", () => {
@@ -762,6 +813,97 @@ describe("wrapUntrustedContent", () => {
   it("contains explicit anti-injection language", () => {
     const result = wrapUntrustedContent("test", "content");
     expect(result).toMatch(/never.*execute|never.*delete|never.*skip/i);
+  });
+});
+
+describe("extractToolDetail", () => {
+  it("extracts file_path for Read tool", () => {
+    const detail = extractToolDetail("Read", { file_path: "/src/main.ts" });
+    expect(detail).toEqual({ file_path: "/src/main.ts" });
+  });
+
+  it("extracts file_path for Edit tool", () => {
+    const detail = extractToolDetail("Edit", { file_path: "/src/utils.ts", old_string: "a", new_string: "b" });
+    expect(detail).toEqual({ file_path: "/src/utils.ts" });
+  });
+
+  it("extracts file_path for Write tool", () => {
+    const detail = extractToolDetail("Write", { file_path: "/src/new.ts", content: "hello" });
+    expect(detail).toEqual({ file_path: "/src/new.ts" });
+  });
+
+  it("redacts sensitive file paths (.env)", () => {
+    const detail = extractToolDetail("Read", { file_path: "/home/user/.env" });
+    expect(detail).toEqual({ file_path: "[REDACTED]" });
+  });
+
+  it("redacts sensitive file paths (.pem)", () => {
+    const detail = extractToolDetail("Read", { file_path: "/home/user/cert.pem" });
+    expect(detail).toEqual({ file_path: "[REDACTED]" });
+  });
+
+  it("redacts sensitive file paths (id_rsa)", () => {
+    const detail = extractToolDetail("Edit", { file_path: "/home/user/.ssh/id_rsa" });
+    expect(detail).toEqual({ file_path: "[REDACTED]" });
+  });
+
+  it("redacts sensitive file paths (.key)", () => {
+    const detail = extractToolDetail("Write", { file_path: "/home/user/server.key", content: "x" });
+    expect(detail).toEqual({ file_path: "[REDACTED]" });
+  });
+
+  it("extracts truncated command for Bash tool", () => {
+    const detail = extractToolDetail("Bash", { command: "echo hello world" });
+    expect(detail).toEqual({ command: "echo hello world" });
+  });
+
+  it("truncates long Bash commands to 120 chars", () => {
+    const longCmd = "a".repeat(200);
+    const detail = extractToolDetail("Bash", { command: longCmd });
+    expect(detail.command).toHaveLength(123); // 120 + "..."
+    expect(detail.command).toMatch(/\.\.\.$/);
+  });
+
+  it("extracts pattern for Glob tool", () => {
+    const detail = extractToolDetail("Glob", { pattern: "**/*.ts" });
+    expect(detail).toEqual({ pattern: "**/*.ts" });
+  });
+
+  it("extracts pattern for Grep tool", () => {
+    const detail = extractToolDetail("Grep", { pattern: "function\\s+\\w+" });
+    expect(detail).toEqual({ pattern: "function\\s+\\w+" });
+  });
+
+  it("returns empty object for unknown tool", () => {
+    const detail = extractToolDetail("UnknownTool", { foo: "bar" });
+    expect(detail).toEqual({});
+  });
+
+  it("returns empty object when input is undefined", () => {
+    const detail = extractToolDetail("Read", undefined);
+    expect(detail).toEqual({});
+  });
+});
+
+describe("formatElapsed", () => {
+  it("formats seconds only", () => {
+    expect(formatElapsed(5000)).toBe("5s");
+  });
+
+  it("formats minutes and seconds", () => {
+    expect(formatElapsed(140000)).toBe("2m20s");
+  });
+
+  it("formats hours, minutes and seconds", () => {
+    expect(formatElapsed(3661000)).toBe("1h1m1s");
+  });
+
+  it("formats zero", () => {
+    expect(formatElapsed(0)).toBe("0s");
+  });
+
+  it("rounds sub-second to 0s", () => {
+    expect(formatElapsed(500)).toBe("0s");
   });
 });
 


### PR DESCRIPTION
## 概要
エージェント実行ログにツール使用の詳細情報（ファイルパス、コマンド、パターン）と状態遷移の経過時間を追加し、デバッグ・観測性を向上させる。

## 変更内容
- `extractToolDetail` ヘルパー関数を追加: Read/Edit/Write → file_path、Bash → truncated command、Glob/Grep → pattern を抽出
- `SECRET_FILE_PATTERNS` を再利用して .env/.pem/id_rsa/.key のファイルパスをログ出力時に `[REDACTED]` に置換
- `formatElapsed` ヘルパー関数を追加: ミリ秒を `2m20s` 形式の人間可読な文字列に変換
- `logAgentProgress` と `formatProgressEvent` に toolDetail フィールドを追加
- `cli.ts` の `onTransition` コールバックで経過時間をログ出力・JSONL 出力に含める
- `engine.ts` の `onTransition` シグネチャに `elapsedMs` パラメータを追加

## テスト
- [x] 既存テストがパスすることを確認（326 tests, 23 files）
- [x] `extractToolDetail` のテストを追加（14 cases: ファイルパス抽出、機密ファイル墨消し、コマンド切り詰め、パターン抽出、未知ツール、undefined入力）
- [x] `formatElapsed` のテストを追加（5 cases）
- [x] `logAgentProgress` の toolDetail 統合テストを追加（3 cases）
- [x] `formatProgressEvent` の toolDetail・elapsed テストを追加（2 cases）

## 関連 Issue
closes #83