### PR TITLE
fix: handle 'nothing to commit' and 'everything up-to-date' in git adapter

### DIFF
--- a/src/adapters/git.ts
+++ b/src/adapters/git.ts
@@ -23,11 +23,25 @@ export function createGitAdapter(): GitAdapter {
     },
 
     async commit(message, cwd) {
-      await execa("git", ["commit", "-m", message], { cwd });
+      try {
+        await execa("git", ["commit", "-m", message], { cwd });
+      } catch (err: any) {
+        if (typeof err.stdout === "string" && err.stdout.includes("nothing to commit")) {
+          return;
+        }
+        throw err;
+      }
     },
 
     async push(branch, cwd) {
-      await execa("git", ["push", "-u", "origin", branch], { cwd });
+      try {
+        await execa("git", ["push", "-u", "origin", branch], { cwd });
+      } catch (err: any) {
+        if (typeof err.stderr === "string" && err.stderr.includes("Everything up-to-date")) {
+          return;
+        }
+        throw err;
+      }
     },
 
     async diff(base, cwd) {

--- a/test/adapters/git.test.ts
+++ b/test/adapters/git.test.ts
@@ -76,6 +76,28 @@ describe("GitAdapter", () => {
         { cwd }
       );
     });
+
+    it("silently succeeds when nothing to commit", async () => {
+      const error = Object.assign(new Error("Command failed"), {
+        exitCode: 1,
+        stdout: "On branch main\nnothing to commit, working tree clean\n",
+        stderr: "",
+      });
+      mockExeca.mockRejectedValueOnce(error);
+      await expect(git.commit("feat: add X", cwd)).resolves.toBeUndefined();
+    });
+
+    it("re-throws genuine git errors", async () => {
+      const error = Object.assign(new Error("Command failed"), {
+        exitCode: 128,
+        stdout: "",
+        stderr: "fatal: Unable to create '.git/index.lock': File exists.",
+      });
+      mockExeca.mockRejectedValueOnce(error);
+      await expect(git.commit("feat: add X", cwd)).rejects.toThrow(
+        "Command failed"
+      );
+    });
   });
 
   describe("push", () => {
@@ -85,6 +107,28 @@ describe("GitAdapter", () => {
         "git",
         ["push", "-u", "origin", "feature/x"],
         { cwd }
+      );
+    });
+
+    it("silently succeeds when everything up-to-date", async () => {
+      const error = Object.assign(new Error("Command failed"), {
+        exitCode: 1,
+        stdout: "",
+        stderr: "Everything up-to-date\n",
+      });
+      mockExeca.mockRejectedValueOnce(error);
+      await expect(git.push("feature/x", cwd)).resolves.toBeUndefined();
+    });
+
+    it("re-throws genuine push errors", async () => {
+      const error = Object.assign(new Error("Command failed"), {
+        exitCode: 128,
+        stdout: "",
+        stderr: "fatal: Authentication failed",
+      });
+      mockExeca.mockRejectedValueOnce(error);
+      await expect(git.push("feature/x", cwd)).rejects.toThrow(
+        "Command failed"
       );
     });
   });


### PR DESCRIPTION
## 概要
git adapter の `commit()` と `push()` が、fixer エージェントが先にコミット/プッシュ済みの場合にクラッシュする問題を修正。

## 変更内容
- `commit()` で `nothing to commit` エラー（exit code 1）を検知し、静かに成功として扱うように変更
- `push()` で `Everything up-to-date` エラーを検知し、静かに成功として扱うように変更
- 上記以外の genuine な git エラーは従来通り re-throw
- 新規テスト4件追加（safe-ignore パスと re-throw パス）

## テスト
- [x] 既存テストがパスすることを確認（378 tests, 27 files）
- [x] 必要に応じて新規テストを追加（4件）

## 関連 Issue
closes #87