### PR TITLE
feat: add .aidev.yml repo config loading and config merging to PR mode init

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ bun run aidev run --pr <number> --repo <owner/name> --cwd <path>
 - `--auto-merge` フラグを指定
 - Issue に `auto-merge` ラベルを付与
 
-#### Issue 本文でのワークフロー設定
+#### Issue / PR 本文でのワークフロー設定
 
-Issue 本文に ` ```aidev ` コードフェンスを記述することで、Issue ごとにワークフローパラメータを指定できる。
+Issue 本文または PR 本文に ` ```aidev ` コードフェンスを記述することで、ワークフローパラメータを指定できる。
 
 ````markdown
 ```aidev
@@ -113,7 +113,9 @@ skip:
 - `watching_ci` — CI 待ちをスキップ（reviewing → merging or done へ直行）
 - `documenter` — ドキュメント更新チェックをスキップ
 
-**優先順位**: CLI フラグ > Issue 本文 > `.aidev.yml` > 環境変数 > デフォルト値
+**優先順位**: CLI フラグ > Issue / PR 本文 > `.aidev.yml` > 環境変数 > デフォルト値
+
+PR モードでは `base` のデフォルトが PR の `baseRefName` となり、そこに上記の優先順位で上書きされる。
 
 #### バックエンド設定
 

--- a/src/workflow/states.ts
+++ b/src/workflow/states.ts
@@ -100,6 +100,68 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
     return runnerByRunId.get(ctx.runId) ?? defaultRunner;
   }
 
+  async function loadAndMergeConfig(
+    ctx: RunContext,
+    body: string,
+    patch: Partial<RunContext>,
+    workItemNumber: number,
+  ): Promise<{ patch: Partial<RunContext>; merged: Partial<IssueConfig> }> {
+    // Load repo-level config (.aidev.yml)
+    const repoConfig = await loadRepoConfig(ctx.cwd);
+    if (Object.keys(repoConfig).length > 0) {
+      logger.info("Loaded repo config", { repoConfig });
+    }
+
+    // Parse config from body (issue body or PR body)
+    const bodyConfig = parseIssueConfig(body);
+    if (Object.keys(bodyConfig).length > 0) {
+      logger.info("Parsed body config", { bodyConfig });
+    }
+
+    // Merge: repo < body, excluding CLI-explicit fields
+    const cliExplicit = ctx._cliExplicit ?? new Set<string>();
+    const merged = mergeConfigs(repoConfig, bodyConfig, cliExplicit);
+
+    if (merged.maxFixAttempts !== undefined) patch.maxFixAttempts = merged.maxFixAttempts;
+    if (merged.maxReviewRounds !== undefined) patch.maxReviewRounds = merged.maxReviewRounds;
+    if (merged.autoMerge !== undefined) patch.autoMerge = merged.autoMerge;
+    if (merged.dryRun !== undefined) patch.dryRun = merged.dryRun;
+    if (merged.base !== undefined) patch.base = merged.base;
+    if (merged.skip) patch.skipStates = merged.skip as SkippableState[];
+
+    // Re-create runner if backend/model changed via config
+    if (merged.backend || merged.model) {
+      const resolved = deps.resolveRunner({
+        backend: merged.backend ?? DEFAULT_BACKEND,
+        model: merged.model,
+      });
+      runnerByRunId.set(ctx.runId, resolved);
+      logger.info("Switched backend from merged config", {
+        backend: merged.backend,
+        model: merged.model,
+      });
+    }
+
+    const mergedCtx = { ...ctx, ...patch };
+
+    // Build resolved config and write back to body
+    const resolvedConfig: ResolvedConfig = {
+      maxFixAttempts: mergedCtx.maxFixAttempts,
+      maxReviewRounds: mergedCtx.maxReviewRounds ?? 1,
+      autoMerge: mergedCtx.autoMerge,
+      dryRun: mergedCtx.dryRun,
+      base: mergedCtx.base,
+      skip: (mergedCtx.skipStates ?? []) as SkippableState[],
+      backend: merged.backend,
+      model: merged.model,
+    };
+    const configBlock = buildResolvedConfigBlock(resolvedConfig);
+    const updatedBody = upsertAidevBlock(body, configBlock);
+    await github.updateIssueBody(workItemNumber, updatedBody);
+
+    return { patch, merged };
+  }
+
   const init: StateHandler = async (ctx) => {
     if (ctx.targetKind === "pr") {
       const pr = await github.getPr(ctx.prNumber!);
@@ -125,7 +187,9 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
         headBranch: pr.headRefName,
       };
 
-      const mergedCtx = { ...ctx, ...patch };
+      const result = await loadAndMergeConfig(ctx, pr.body, patch, pr.number);
+
+      const mergedCtx = { ...ctx, ...result.patch };
       await git.createBranch(
         mergedCtx.branch,
         `origin/${pr.headRefName}`,
@@ -153,63 +217,14 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
       }
     }
 
-    // Load repo-level config (.aidev.yml)
-    const repoConfig = await loadRepoConfig(ctx.cwd);
-    if (Object.keys(repoConfig).length > 0) {
-      logger.info("Loaded repo config", { repoConfig });
-    }
-
-    // Parse issue config from body
-    const issueConfig = parseIssueConfig(issue.body);
-    if (Object.keys(issueConfig).length > 0) {
-      logger.info("Parsed issue config", { issueConfig });
-    }
-
-    // Merge: repo < issue, excluding CLI-explicit fields
-    const cliExplicit = ctx._cliExplicit ?? new Set<string>();
-    const merged = mergeConfigs(repoConfig, issueConfig, cliExplicit);
-
     const patch: Partial<RunContext> = {
       issueLabels: issue.labels,
       issueTitle: issue.title,
     };
 
-    if (merged.maxFixAttempts !== undefined) patch.maxFixAttempts = merged.maxFixAttempts;
-    if (merged.maxReviewRounds !== undefined) patch.maxReviewRounds = merged.maxReviewRounds;
-    if (merged.autoMerge !== undefined) patch.autoMerge = merged.autoMerge;
-    if (merged.dryRun !== undefined) patch.dryRun = merged.dryRun;
-    if (merged.base !== undefined) patch.base = merged.base;
-    if (merged.skip) patch.skipStates = merged.skip as SkippableState[];
+    const result = await loadAndMergeConfig(ctx, issue.body, patch, issue.number);
 
-    // Re-create runner if backend/model changed via Issue or repo config
-    if (merged.backend || merged.model) {
-      const resolved = deps.resolveRunner({
-        backend: merged.backend ?? DEFAULT_BACKEND,
-        model: merged.model,
-      });
-      runnerByRunId.set(ctx.runId, resolved);
-      logger.info("Switched backend from merged config", {
-        backend: merged.backend,
-        model: merged.model,
-      });
-    }
-
-    const mergedCtx = { ...ctx, ...patch };
-
-    // Build resolved config and write back to issue body
-    const resolvedConfig: ResolvedConfig = {
-      maxFixAttempts: mergedCtx.maxFixAttempts,
-      maxReviewRounds: mergedCtx.maxReviewRounds ?? 1,
-      autoMerge: mergedCtx.autoMerge,
-      dryRun: mergedCtx.dryRun,
-      base: mergedCtx.base,
-      skip: (mergedCtx.skipStates ?? []) as SkippableState[],
-      backend: merged.backend,
-      model: merged.model,
-    };
-    const configBlock = buildResolvedConfigBlock(resolvedConfig);
-    const updatedBody = upsertAidevBlock(issue.body, configBlock);
-    await github.updateIssueBody(issue.number, updatedBody);
+    const mergedCtx = { ...ctx, ...result.patch };
 
     await git.createBranch(mergedCtx.branch, mergedCtx.base, mergedCtx.cwd);
     logger.info("Created branch", { branch: mergedCtx.branch });

--- a/test/workflow/states.test.ts
+++ b/test/workflow/states.test.ts
@@ -455,7 +455,187 @@ describe("init handler", () => {
       "origin/feat/head",
       ctx.cwd
     );
-    expect(deps.github.updateIssueBody).not.toHaveBeenCalled();
+    // Resolved config is written back to PR body
+    expect(deps.github.updateIssueBody).toHaveBeenCalledWith(
+      5,
+      expect.stringContaining("```aidev"),
+    );
+  });
+
+  it("PR mode loads .aidev.yml and applies maxReviewRounds from repo config", async () => {
+    const deps = makeDeps({
+      loadRepoConfig: vi.fn(async () => ({ maxReviewRounds: 3, autoMerge: true })),
+      github: {
+        getPr: vi.fn(async () => ({
+          number: 5,
+          title: "Test PR",
+          body: "PR body",
+          baseRefName: "main",
+          headRefName: "feat/head",
+          author: "testuser",
+        })),
+      },
+    });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      targetKind: "pr",
+      prNumber: 5,
+      branch: "placeholder",
+      base: "main",
+    });
+
+    const result = await handlers.init!(ctx);
+
+    expect(result.ctx.maxReviewRounds).toBe(3);
+    expect(result.ctx.autoMerge).toBe(true);
+    expect(deps.loadRepoConfig).toHaveBeenCalledWith(ctx.cwd);
+  });
+
+  it("PR mode parses aidev block from PR body and merges into ctx", async () => {
+    const deps = makeDeps({
+      github: {
+        getPr: vi.fn(async () => ({
+          number: 5,
+          title: "Test PR",
+          body: "Some description\n```aidev\nmaxFixAttempts: 7\nautoMerge: true\nbase: release/2.0\nskip:\n  - reviewing\n```",
+          baseRefName: "main",
+          headRefName: "feat/head",
+          author: "testuser",
+        })),
+      },
+    });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      targetKind: "pr",
+      prNumber: 5,
+      branch: "placeholder",
+      base: "main",
+    });
+
+    const result = await handlers.init!(ctx);
+
+    expect(result.ctx.maxFixAttempts).toBe(7);
+    expect(result.ctx.autoMerge).toBe(true);
+    expect(result.ctx.base).toBe("release/2.0");
+    expect(result.ctx.skipStates).toEqual(["reviewing"]);
+  });
+
+  it("PR mode respects CLI-explicit flags over repo/PR config", async () => {
+    const deps = makeDeps({
+      loadRepoConfig: vi.fn(async () => ({ base: "develop" })),
+      github: {
+        getPr: vi.fn(async () => ({
+          number: 5,
+          title: "Test PR",
+          body: "```aidev\nbase: release/1.0\n```",
+          baseRefName: "main",
+          headRefName: "feat/head",
+          author: "testuser",
+        })),
+      },
+    });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      targetKind: "pr",
+      prNumber: 5,
+      branch: "placeholder",
+      base: "cli-branch",
+      _cliExplicit: new Set(["base"]),
+    });
+
+    const result = await handlers.init!(ctx);
+
+    expect(result.ctx.base).toBe("cli-branch");
+  });
+
+  it("PR mode switches backend/model when config specifies them", async () => {
+    const deps = makeDeps({
+      github: {
+        getPr: vi.fn(async () => ({
+          number: 5,
+          title: "Test PR",
+          body: "```aidev\nbackend: openai\nmodel: gpt-4\n```",
+          baseRefName: "main",
+          headRefName: "feat/head",
+          author: "testuser",
+        })),
+      },
+    });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      targetKind: "pr",
+      prNumber: 5,
+      branch: "placeholder",
+      base: "main",
+    });
+
+    await handlers.init!(ctx);
+
+    expect(deps.resolveRunner).toHaveBeenCalledWith({
+      backend: "openai",
+      model: "gpt-4",
+    });
+  });
+
+  it("PR mode writes resolved config back to PR body", async () => {
+    const deps = makeDeps({
+      github: {
+        getPr: vi.fn(async () => ({
+          number: 5,
+          title: "Test PR",
+          body: "PR description here",
+          baseRefName: "main",
+          headRefName: "feat/head",
+          author: "testuser",
+        })),
+      },
+    });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      targetKind: "pr",
+      prNumber: 5,
+      branch: "placeholder",
+      base: "main",
+    });
+
+    await handlers.init!(ctx);
+
+    expect(deps.github.updateIssueBody).toHaveBeenCalledWith(
+      5,
+      expect.stringContaining("```aidev"),
+    );
+    expect(deps.github.updateIssueBody).toHaveBeenCalledWith(
+      5,
+      expect.stringContaining("PR description here"),
+    );
+  });
+
+  it("PR mode: pr.baseRefName is default, config base overrides it", async () => {
+    const deps = makeDeps({
+      loadRepoConfig: vi.fn(async () => ({ base: "develop" })),
+      github: {
+        getPr: vi.fn(async () => ({
+          number: 5,
+          title: "Test PR",
+          body: "PR body",
+          baseRefName: "feat/base",
+          headRefName: "feat/head",
+          author: "testuser",
+        })),
+      },
+    });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      targetKind: "pr",
+      prNumber: 5,
+      branch: "placeholder",
+      base: "main",
+    });
+
+    const result = await handlers.init!(ctx);
+
+    // repo config base overrides pr.baseRefName
+    expect(result.ctx.base).toBe("develop");
   });
 });
 


### PR DESCRIPTION
## 概要
PR モードの init ハンドラに `.aidev.yml` リポジトリ設定の読み込みとコンフィグマージ機能を追加。Issue モードと同等の設定機能を PR モードでも利用可能にする。

## 変更内容
- `loadAndMergeConfig` ヘルパー関数を抽出し、PR/Issue 両モードで共通利用
- PR モードで `.aidev.yml` の `maxReviewRounds`, `maxFixAttempts`, `autoMerge`, `dryRun` 等を適用
- PR body の aidev ブロックからの設定パースに対応
- 設定マージ優先順位: `pr.baseRefName`（デフォルト）< `.aidev.yml` < PR body aidev block < CLI フラグ
- PR body への resolved config 書き戻し
- backend/model の動的切り替えを PR モードでもサポート

## テスト
- [x] 既存テストがパスすることを確認（全385テスト通過）
- [x] PR mode の新規テスト6件を追加（repo config 読み込み、PR body パース、CLI 優先、backend/model 切り替え、resolved config 書き戻し、base 優先順位）

## 関連 Issue
closes #95

```aidev
maxFixAttempts: 3
maxReviewRounds: 5
autoMerge: false
dryRun: false
base: main
```