### PR TITLE
fix: reuse existing worktree on resume to preserve in-progress changes

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -313,7 +313,7 @@ export function createCli() {
       // Non-terminal states and done+dryRun (→creating_pr) need existing changes preserved.
       const terminalStates = new Set(["done", "failed", "blocked"]);
       const shouldReuseWorktree = opts.resume
-        && !(terminalStates.has(ctx.state) && !(ctx.state === "done" && ctx.dryRun));
+        && (!terminalStates.has(ctx.state) || (ctx.state === "done" && ctx.dryRun));
 
       try {
         if (shouldReuseWorktree) {
@@ -322,6 +322,7 @@ export function createCli() {
             process.exit(1);
           }
           ctx.cwd = worktreePath;
+          worktreeCreated = true;
           logger.info("Reusing existing worktree for resume", { path: worktreePath });
         } else {
           // Remove stale worktree from a previous interrupted run, if any

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
 import { mkdir, writeFile, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
@@ -306,13 +307,30 @@ export function createCli() {
 
       let exitCode = 0;
       let worktreeCreated = false;
+
+      // Determine whether to reuse existing worktree on resume.
+      // Terminal states (done without dryRun, failed, blocked) get a fresh worktree.
+      // Non-terminal states and done+dryRun (→creating_pr) need existing changes preserved.
+      const terminalStates = new Set(["done", "failed", "blocked"]);
+      const shouldReuseWorktree = opts.resume
+        && !(terminalStates.has(ctx.state) && !(ctx.state === "done" && ctx.dryRun));
+
       try {
-        // Remove stale worktree from a previous interrupted run, if any
-        await git.removeWorktree(worktreePath, originalCwd).catch(() => {});
-        await git.addWorktree(worktreePath, ctx.base, originalCwd);
-        worktreeCreated = true;
-        ctx.cwd = worktreePath;
-        logger.info("Created worktree", { path: worktreePath, base: ctx.base });
+        if (shouldReuseWorktree) {
+          if (!existsSync(worktreePath)) {
+            logger.error("Worktree not found for resume. The previous worktree may have been cleaned up.", { path: worktreePath });
+            process.exit(1);
+          }
+          ctx.cwd = worktreePath;
+          logger.info("Reusing existing worktree for resume", { path: worktreePath });
+        } else {
+          // Remove stale worktree from a previous interrupted run, if any
+          await git.removeWorktree(worktreePath, originalCwd).catch(() => {});
+          await git.addWorktree(worktreePath, ctx.base, originalCwd);
+          worktreeCreated = true;
+          ctx.cwd = worktreePath;
+          logger.info("Created worktree", { path: worktreePath, base: ctx.base });
+        }
 
         const result = await runWorkflow(ctx, handlers, persistence, {
           logger,

--- a/test/cli-watch.test.ts
+++ b/test/cli-watch.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock modules before any imports
-const { mockAddWorktree, mockRemoveWorktree, mockRunPreflightChecks } = vi.hoisted(() => ({
+const { mockAddWorktree, mockRemoveWorktree, mockRunPreflightChecks, mockExistsSync } = vi.hoisted(() => ({
   mockAddWorktree: vi.fn(async () => {}),
   mockRemoveWorktree: vi.fn(async () => {}),
   mockRunPreflightChecks: vi.fn(async () => {}),
+  mockExistsSync: vi.fn(() => false),
 }));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, existsSync: mockExistsSync };
+});
 
 vi.mock("../src/adapters/git.js", () => ({
   createGitAdapter: vi.fn(() => ({
@@ -930,9 +936,7 @@ describe("run command", () => {
     expect(mockRemoveWorktree).toHaveBeenCalledTimes(2);
   });
 
-  it("creates worktree from opts.cwd even when resuming (saved cwd may be stale)", async () => {
-    // When resuming, ctx.cwd from saved state points to a now-deleted worktree path.
-    // The worktree should be created from opts.cwd (the original repo), not ctx.cwd.
+  it("reuses existing worktree when resuming non-terminal state", async () => {
     const { mkdtemp, mkdir, writeFile, rm } = await import("node:fs/promises");
     const { tmpdir } = await import("node:os");
     const { join } = await import("node:path");
@@ -948,7 +952,138 @@ describe("run command", () => {
         issueNumber: 42,
         repo: "owner/repo",
         cwd: "/tmp/stale-worktree/.worktrees/issue-42",
-        state: "planning",
+        state: "implementing",
+        branch: "aidev/issue-42",
+        base: "main",
+        maxFixAttempts: 3,
+        fixAttempts: 0,
+        dryRun: false,
+        autoMerge: false,
+        issueLabels: [],
+        skipAuthorCheck: false,
+        skipStates: [],
+      })
+    );
+
+    const originalHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    // Worktree exists on disk
+    mockExistsSync.mockReturnValue(true);
+
+    try {
+      const mockRunWorkflow = vi.mocked(runWorkflow);
+      mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+        ...ctx,
+        state: "done",
+      }));
+
+      const cli = createCli();
+      await cli.parseAsync([
+        "node",
+        "aidev",
+        "run",
+        "--issue",
+        "42",
+        "--repo",
+        "owner/repo",
+        "--cwd",
+        "/tmp/real-repo",
+        "--resume",
+        "--yes",
+      ]);
+
+      // Should NOT remove or add worktree — reuse existing
+      expect(mockRemoveWorktree).not.toHaveBeenCalled();
+      expect(mockAddWorktree).not.toHaveBeenCalled();
+
+      // ctx.cwd should be the worktree path derived from opts.cwd
+      const ctx = mockRunWorkflow.mock.calls[0][0];
+      expect(ctx.cwd).toContain("/tmp/real-repo/.worktrees/issue-42");
+    } finally {
+      mockExistsSync.mockReturnValue(false);
+      process.env.HOME = originalHome;
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it("errors when resuming non-terminal state but worktree does not exist", async () => {
+    const { mkdtemp, mkdir, writeFile, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const tempHome = await mkdtemp(join(tmpdir(), "aidev-resume-"));
+    const runDir = join(tempHome, ".aidev", "runs", "run-resume-test");
+    await mkdir(runDir, { recursive: true });
+    await writeFile(
+      join(runDir, "state.json"),
+      JSON.stringify({
+        runId: "run-resume-test",
+        targetKind: "issue",
+        issueNumber: 42,
+        repo: "owner/repo",
+        cwd: "/tmp/stale-worktree/.worktrees/issue-42",
+        state: "implementing",
+        branch: "aidev/issue-42",
+        base: "main",
+        maxFixAttempts: 3,
+        fixAttempts: 0,
+        dryRun: false,
+        autoMerge: false,
+        issueLabels: [],
+        skipAuthorCheck: false,
+        skipStates: [],
+      })
+    );
+
+    const originalHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    // Worktree does NOT exist on disk
+    mockExistsSync.mockReturnValue(false);
+
+    try {
+      const cli = createCli();
+      await cli.parseAsync([
+        "node",
+        "aidev",
+        "run",
+        "--issue",
+        "42",
+        "--repo",
+        "owner/repo",
+        "--cwd",
+        "/tmp/real-repo",
+        "--resume",
+        "--yes",
+      ]);
+
+      // Should exit with error
+      expect(process.exit).toHaveBeenCalledWith(1);
+    } finally {
+      mockExistsSync.mockReturnValue(false);
+      process.env.HOME = originalHome;
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it("recreates worktree when resuming from terminal state (failed)", async () => {
+    const { mkdtemp, mkdir, writeFile, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const tempHome = await mkdtemp(join(tmpdir(), "aidev-resume-"));
+    const runDir = join(tempHome, ".aidev", "runs", "run-resume-test");
+    await mkdir(runDir, { recursive: true });
+    await writeFile(
+      join(runDir, "state.json"),
+      JSON.stringify({
+        runId: "run-resume-test",
+        targetKind: "issue",
+        issueNumber: 42,
+        repo: "owner/repo",
+        cwd: "/tmp/stale-worktree/.worktrees/issue-42",
+        state: "failed",
         branch: "aidev/issue-42",
         base: "main",
         maxFixAttempts: 3,
@@ -986,13 +1121,84 @@ describe("run command", () => {
         "--yes",
       ]);
 
-      // Worktree should be created from /tmp/real-repo, NOT from the stale saved cwd
+      // Terminal state → should recreate worktree (remove + add)
+      expect(mockRemoveWorktree).toHaveBeenCalled();
       expect(mockAddWorktree).toHaveBeenCalledWith(
         expect.stringContaining("/tmp/real-repo/.worktrees/issue-42"),
         "main",
         "/tmp/real-repo",
       );
     } finally {
+      process.env.HOME = originalHome;
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it("reuses worktree when resuming done+dryRun (transitions to creating_pr)", async () => {
+    const { mkdtemp, mkdir, writeFile, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const tempHome = await mkdtemp(join(tmpdir(), "aidev-resume-"));
+    const runDir = join(tempHome, ".aidev", "runs", "run-resume-test");
+    await mkdir(runDir, { recursive: true });
+    await writeFile(
+      join(runDir, "state.json"),
+      JSON.stringify({
+        runId: "run-resume-test",
+        targetKind: "issue",
+        issueNumber: 42,
+        repo: "owner/repo",
+        cwd: "/tmp/stale-worktree/.worktrees/issue-42",
+        state: "done",
+        branch: "aidev/issue-42",
+        base: "main",
+        maxFixAttempts: 3,
+        fixAttempts: 0,
+        dryRun: true,
+        autoMerge: false,
+        issueLabels: [],
+        skipAuthorCheck: false,
+        skipStates: [],
+      })
+    );
+
+    const originalHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    // Worktree exists
+    mockExistsSync.mockReturnValue(true);
+
+    try {
+      const mockRunWorkflow = vi.mocked(runWorkflow);
+      mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+        ...ctx,
+        state: "done",
+      }));
+
+      const cli = createCli();
+      await cli.parseAsync([
+        "node",
+        "aidev",
+        "run",
+        "--issue",
+        "42",
+        "--repo",
+        "owner/repo",
+        "--cwd",
+        "/tmp/real-repo",
+        "--resume",
+        "--yes",
+      ]);
+
+      // done + dryRun → creating_pr, needs existing changes → reuse worktree
+      expect(mockRemoveWorktree).not.toHaveBeenCalled();
+      expect(mockAddWorktree).not.toHaveBeenCalled();
+
+      const ctx = mockRunWorkflow.mock.calls[0][0];
+      expect(ctx.state).toBe("creating_pr");
+    } finally {
+      mockExistsSync.mockReturnValue(false);
       process.env.HOME = originalHome;
       await rm(tempHome, { recursive: true, force: true });
     }

--- a/test/cli-watch.test.ts
+++ b/test/cli-watch.test.ts
@@ -993,9 +993,11 @@ describe("run command", () => {
         "--yes",
       ]);
 
-      // Should NOT remove or add worktree — reuse existing
-      expect(mockRemoveWorktree).not.toHaveBeenCalled();
+      // Should NOT add worktree — reuse existing
       expect(mockAddWorktree).not.toHaveBeenCalled();
+
+      // removeWorktree should only be called once in finally (cleanup), not before
+      expect(mockRemoveWorktree).toHaveBeenCalledTimes(1);
 
       // ctx.cwd should be the worktree path derived from opts.cwd
       const ctx = mockRunWorkflow.mock.calls[0][0];
@@ -1192,8 +1194,10 @@ describe("run command", () => {
       ]);
 
       // done + dryRun → creating_pr, needs existing changes → reuse worktree
-      expect(mockRemoveWorktree).not.toHaveBeenCalled();
       expect(mockAddWorktree).not.toHaveBeenCalled();
+
+      // removeWorktree should only be called once in finally (cleanup), not before
+      expect(mockRemoveWorktree).toHaveBeenCalledTimes(1);
 
       const ctx = mockRunWorkflow.mock.calls[0][0];
       expect(ctx.state).toBe("creating_pr");


### PR DESCRIPTION
## 概要
resume 時に worktree を毎回 remove → add していたため、前回の implementing ステートで生成されたコード変更が消え、committing ステートで commit するものがなくなりクラッシュする問題を修正。

## 変更内容
- `src/cli.ts`: resume 時の worktree 作成ロジックを分岐
  - resume + 非 terminal state: 既存 worktree をそのまま再利用（removeWorktree/addWorktree をスキップ）
  - resume + terminal state（failed/blocked/done without dryRun）: 新規実行として worktree を作り直す
  - resume + done + dryRun: worktree を再利用（creating_pr に遷移するため変更が必要）
  - resume + worktree が存在しない場合: エラーメッセージを表示して終了
- `test/cli-watch.test.ts`: 新しい分岐に合わせてテストを更新・追加
  - `existsSync` のモックを追加
  - 既存の resume テストを worktree 再利用の検証に変更
  - worktree 不在時のエラー終了テストを追加
  - terminal state からの再実行で worktree が作り直されるテストを追加
  - done+dryRun で worktree が再利用されるテストを追加

## テスト
- [x] 既存テストがパスすることを確認（全458テスト pass）
- [x] resume 時に既存 worktree があれば再利用されることを確認
- [x] resume 時に worktree が存在しない場合エラーで終了することを確認
- [x] terminal state からの再実行で worktree が作り直されることを確認
- [x] done+dryRun からの resume で worktree が再利用されることを確認

## 関連 Issue
closes #116