### PR TITLE
feat: add manual_handoff state and wall-clock timeouts (v2)

### DIFF
--- a/src/adapters/slack.ts
+++ b/src/adapters/slack.ts
@@ -3,7 +3,7 @@ export interface SlackMessageInput {
   targetNumber: number;
   issueTitle?: string;
   repo: string;
-  finalState: "done" | "failed" | "blocked";
+  finalState: "done" | "failed" | "blocked" | "manual_handoff";
   elapsedMs: number;
   prNumber?: number;
 }
@@ -26,8 +26,8 @@ function formatElapsed(ms: number): string {
 }
 
 export function formatSlackMessage(input: SlackMessageInput): string {
-  const iconMap = { done: ":white_check_mark:", failed: ":x:", blocked: ":warning:" } as const;
-  const statusMap = { done: "completed", failed: "failed", blocked: "blocked" } as const;
+  const iconMap = { done: ":white_check_mark:", failed: ":x:", blocked: ":warning:", manual_handoff: ":raised_hand:" } as const;
+  const statusMap = { done: "completed", failed: "failed", blocked: "blocked", manual_handoff: "handed off" } as const;
   const icon = iconMap[input.finalState];
   const status = statusMap[input.finalState];
   const targetLabel = input.targetKind === "pr" ? "PR" : "Issue";

--- a/src/adapters/slack.ts
+++ b/src/adapters/slack.ts
@@ -1,9 +1,11 @@
+import type { TerminalState } from "../types.js";
+
 export interface SlackMessageInput {
   targetKind: "issue" | "pr";
   targetNumber: number;
   issueTitle?: string;
   repo: string;
-  finalState: "done" | "failed" | "blocked" | "manual_handoff";
+  finalState: TerminalState;
   elapsedMs: number;
   prNumber?: number;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,9 @@ function createFilePersistence(baseDir: string): Persistence {
     async save(ctx) {
       const dir = join(baseDir, ctx.runId);
       await mkdir(dir, { recursive: true });
-      await writeFile(join(dir, "state.json"), JSON.stringify(ctx, null, 2));
+      // Strip transient fields that are not JSON-serializable or not meaningful across sessions
+      const { _abortSignal, _cliExplicit, ...serializable } = ctx;
+      await writeFile(join(dir, "state.json"), JSON.stringify(serializable, null, 2));
 
       if (ctx.plan)
         await writeFile(
@@ -473,7 +475,9 @@ export function createCli() {
         process.stdout.write(JSON.stringify(output) + "\n");
         exitCode = 1;
       } finally {
-        if (worktreeCreated && resultState !== "manual_handoff") {
+        // Preserve worktree if workflow reached manual_handoff (even if crash happened after)
+        const shouldPreserve = resultState === "manual_handoff" || lastKnownState === "manual_handoff";
+        if (worktreeCreated && !shouldPreserve) {
           await git.removeWorktree(worktreePath, originalCwd).catch((err) =>
             logger.error("Worktree cleanup failed", {
               path: worktreePath,
@@ -481,7 +485,7 @@ export function createCli() {
             })
           );
         }
-        if (resultState === "manual_handoff") {
+        if (shouldPreserve) {
           logger.info("Worktree preserved for resume", { path: worktreePath });
         }
       }
@@ -642,8 +646,11 @@ export function createCli() {
                   worktreePath,
                   resumeCommand: `aidev run --issue ${issue.number} --repo ${repo} --cwd ${cwd} --resume --yes`,
                 });
+                // Mark as failed so re-labeling can trigger a retry
+                processedIssues.set(issue.number, "failed");
+              } else {
+                processedIssues.set(issue.number, "done");
               }
-              processedIssues.set(issue.number, "done");
             } catch (err) {
               processedIssues.set(issue.number, "failed");
               throw err;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ import { createSlackNotifier, formatSlackMessage } from "./adapters/slack.js";
 import { loadRepoConfig } from "./config/repo-config.js";
 import { writeAidevYml } from "./config/init.js";
 import { runPreflightChecks } from "./preflight.js";
-import type { RunContext } from "./types.js";
+import { RunStateSchema, type RunContext } from "./types.js";
 import { formatElapsed, formatProgressEvent } from "./agents/shared.js";
 import { formatErrorDetails } from "./util/error.js";
 
@@ -185,6 +185,10 @@ export function createCli() {
         // (commit already exists, just need push + PR)
         if (saved.state === "done" && saved.dryRun) {
           ctx.state = "creating_pr";
+        }
+        // If previous run was handed off due to timeout, resume from the timed-out state
+        if (saved.state === "manual_handoff" && saved._timedOutState) {
+          ctx.state = RunStateSchema.parse(saved._timedOutState);
         }
       } else {
         const runId = `run-${Date.now()}-${randomUUID().slice(0, 8)}`;
@@ -365,7 +369,7 @@ export function createCli() {
               targetNumber: finalCtx.issueNumber ?? finalCtx.prNumber!,
               issueTitle: finalCtx.issueTitle,
               repo: finalCtx.repo,
-              finalState: finalCtx.state as "done" | "failed" | "blocked",
+              finalState: finalCtx.state as "done" | "failed" | "blocked" | "manual_handoff",
               elapsedMs,
               prNumber: finalCtx.prNumber,
             });
@@ -383,6 +387,16 @@ export function createCli() {
             summary: result.result?.changeSummary,
           };
           process.stdout.write(JSON.stringify(output) + "\n");
+        } else if (result.state === "manual_handoff") {
+          logger.warn("Devloop handed off - needs human intervention", { runId: ctx.runId });
+          const output = {
+            status: "manual_handoff" as const,
+            runId: result.runId,
+            timedOutState: result._timedOutState,
+            reason: result.handoffReason,
+          };
+          process.stdout.write(JSON.stringify(output) + "\n");
+          exitCode = 1;
         } else if (result.state === "blocked") {
           logger.warn("Devloop blocked - needs human discussion", { runId: ctx.runId });
           const output = {
@@ -544,7 +558,7 @@ export function createCli() {
                     targetNumber: finalCtx.issueNumber ?? finalCtx.prNumber!,
                     issueTitle: finalCtx.issueTitle,
                     repo: finalCtx.repo,
-                    finalState: finalCtx.state as "done" | "failed" | "blocked",
+                    finalState: finalCtx.state as "done" | "failed" | "blocked" | "manual_handoff",
                     elapsedMs,
                     prNumber: finalCtx.prNumber,
                   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -547,6 +547,7 @@ export function createCli() {
       // Track issue status: allow retrying failed issues on next label scan
       const processedIssues = new Map<number, "running" | "done" | "failed">();
       let concurrentRuns = 0;
+      let shuttingDown = false;
       const MAX_CONCURRENT_RUNS = 2;
 
       const poll = async () => {
@@ -656,6 +657,10 @@ export function createCli() {
               throw err;
             } finally {
               concurrentRuns--;
+              if (shuttingDown && concurrentRuns === 0) {
+                logger.info("All in-flight runs completed after shutdown signal, exiting");
+                process.exit(0);
+              }
               if (!preserveWorktree) {
                 await git.removeWorktree(worktreePath, cwd).catch((err) =>
                   runLogger.error("Worktree cleanup failed", {
@@ -687,10 +692,11 @@ export function createCli() {
 
       // Graceful shutdown on SIGTERM/SIGINT
       const shutdown = () => {
+        shuttingDown = true;
         clearInterval(intervalId);
         logger.info("Shutting down watch mode", { inFlightRuns: concurrentRuns });
-        // Allow in-flight runs to complete naturally; process exits when they finish
         if (concurrentRuns === 0) process.exit(0);
+        // In-flight runs will exit via the finally block when they complete
       };
       process.on("SIGTERM", shutdown);
       process.on("SIGINT", shutdown);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ import { createSlackNotifier, formatSlackMessage } from "./adapters/slack.js";
 import { loadRepoConfig } from "./config/repo-config.js";
 import { writeAidevYml } from "./config/init.js";
 import { runPreflightChecks } from "./preflight.js";
-import { RunStateSchema, TERMINAL_STATES, isTerminalState, type RunContext, type TerminalState } from "./types.js";
+import { RunStateSchema, TERMINAL_STATES, isTerminalState, type RunContext, type RunState, type TerminalState } from "./types.js";
 import { formatElapsed, formatProgressEvent } from "./agents/shared.js";
 import { formatErrorDetails } from "./util/error.js";
 
@@ -205,13 +205,21 @@ export function createCli() {
           // Clear handoff metadata to avoid stale data in the resumed run
           delete ctx._timedOutState;
           delete ctx.handoffReason;
-          // Clear stateTimeouts to prevent re-triggering the same timeout.
-          // User can re-specify via issue body if desired.
-          if (ctx.stateTimeouts) {
-            logger.info("Clearing stateTimeouts for resume to prevent repeated handoff", {
-              previousTimeouts: ctx.stateTimeouts,
-            });
-            delete ctx.stateTimeouts;
+          // Clear only the timeout for the state that timed out to prevent
+          // re-triggering. Other state timeouts remain in effect.
+          if (ctx.stateTimeouts && saved._timedOutState) {
+            const timedOutKey = saved._timedOutState as RunState;
+            if (ctx.stateTimeouts[timedOutKey] != null) {
+              logger.info("Clearing timeout for timed-out state", {
+                state: timedOutKey,
+                removedTimeout: ctx.stateTimeouts[timedOutKey],
+                remainingTimeouts: Object.keys(ctx.stateTimeouts).filter(k => k !== timedOutKey),
+              });
+              delete ctx.stateTimeouts[timedOutKey];
+              if (Object.keys(ctx.stateTimeouts).length === 0) {
+                delete ctx.stateTimeouts;
+              }
+            }
           }
         }
       } else {
@@ -477,8 +485,8 @@ export function createCli() {
           logger.info("Worktree preserved for resume", { path: worktreePath });
         }
       }
+      await logger.flush();
       if (exitCode !== 0) {
-        await logger.flush();
         process.exit(exitCode);
       }
     });
@@ -531,19 +539,33 @@ export function createCli() {
       logger.info("Watching for issues", { label: opts.label, repo });
 
       const authenticatedUser = await github.getAuthenticatedUser();
-      const processedIssues = new Set<number>();
+
+      // Track issue status: allow retrying failed issues on next label scan
+      const processedIssues = new Map<number, "running" | "done" | "failed">();
+      let concurrentRuns = 0;
+      const MAX_CONCURRENT_RUNS = 2;
 
       const poll = async () => {
         const issues = await github.listIssuesByLabel(opts.label);
         for (const issue of issues) {
-          if (processedIssues.has(issue.number)) continue;
-          processedIssues.add(issue.number);
+          const status = processedIssues.get(issue.number);
+          if (status === "running" || status === "done") continue;
 
           if (issue.author !== authenticatedUser) {
             logger.warn("Skipping foreign issue", {
               number: issue.number,
               author: issue.author,
               authenticatedUser,
+            });
+            processedIssues.set(issue.number, "done");
+            continue;
+          }
+
+          if (concurrentRuns >= MAX_CONCURRENT_RUNS) {
+            logger.info("Concurrency limit reached, deferring issue", {
+              number: issue.number,
+              concurrentRuns,
+              max: MAX_CONCURRENT_RUNS,
             });
             continue;
           }
@@ -555,6 +577,8 @@ export function createCli() {
 
           const runId = `run-${Date.now()}-${randomUUID().slice(0, 8)}`;
           const worktreePath = join(cwd, ".worktrees", `issue-${issue.number}`);
+          processedIssues.set(issue.number, "running");
+          concurrentRuns++;
 
           const runIssue = async () => {
             const runLogDir = join(baseDir, runId);
@@ -619,7 +643,12 @@ export function createCli() {
                   resumeCommand: `aidev run --issue ${issue.number} --repo ${repo} --cwd ${cwd} --resume --yes`,
                 });
               }
+              processedIssues.set(issue.number, "done");
+            } catch (err) {
+              processedIssues.set(issue.number, "failed");
+              throw err;
             } finally {
+              concurrentRuns--;
               if (!preserveWorktree) {
                 await git.removeWorktree(worktreePath, cwd).catch((err) =>
                   runLogger.error("Worktree cleanup failed", {
@@ -641,7 +670,23 @@ export function createCli() {
       };
 
       await poll();
-      setInterval(poll, opts.interval * 1000);
+      const intervalId = setInterval(async () => {
+        try {
+          await poll();
+        } catch (err) {
+          logger.error("Poll cycle failed", { ...formatErrorDetails(err) });
+        }
+      }, opts.interval * 1000);
+
+      // Graceful shutdown on SIGTERM/SIGINT
+      const shutdown = () => {
+        clearInterval(intervalId);
+        logger.info("Shutting down watch mode", { inFlightRuns: concurrentRuns });
+        // Allow in-flight runs to complete naturally; process exits when they finish
+        if (concurrentRuns === 0) process.exit(0);
+      };
+      process.on("SIGTERM", shutdown);
+      process.on("SIGINT", shutdown);
     });
 
   program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -187,14 +187,19 @@ export function createCli() {
           ctx.state = "creating_pr";
         }
         // If previous run was handed off due to timeout, resume from the timed-out state
-        if (saved.state === "manual_handoff" && saved._timedOutState) {
-          const parsed = RunStateSchema.safeParse(saved._timedOutState);
-          if (parsed.success) {
-            ctx.state = parsed.data;
+        if (saved.state === "manual_handoff") {
+          if (saved._timedOutState) {
+            const parsed = RunStateSchema.safeParse(saved._timedOutState);
+            if (parsed.success) {
+              ctx.state = parsed.data;
+            } else {
+              logger.error("Invalid _timedOutState in saved run, falling back to init", {
+                _timedOutState: saved._timedOutState,
+              });
+              ctx.state = "init";
+            }
           } else {
-            logger.error("Invalid _timedOutState in saved run, falling back to init", {
-              _timedOutState: saved._timedOutState,
-            });
+            logger.warn("Resuming from manual_handoff with no _timedOutState, restarting from init");
             ctx.state = "init";
           }
         }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ import { createSlackNotifier, formatSlackMessage } from "./adapters/slack.js";
 import { loadRepoConfig } from "./config/repo-config.js";
 import { writeAidevYml } from "./config/init.js";
 import { runPreflightChecks } from "./preflight.js";
-import { RunStateSchema, type RunContext } from "./types.js";
+import { RunStateSchema, type RunContext, type TerminalState } from "./types.js";
 import { formatElapsed, formatProgressEvent } from "./agents/shared.js";
 import { formatErrorDetails } from "./util/error.js";
 
@@ -188,7 +188,15 @@ export function createCli() {
         }
         // If previous run was handed off due to timeout, resume from the timed-out state
         if (saved.state === "manual_handoff" && saved._timedOutState) {
-          ctx.state = RunStateSchema.parse(saved._timedOutState);
+          const parsed = RunStateSchema.safeParse(saved._timedOutState);
+          if (parsed.success) {
+            ctx.state = parsed.data;
+          } else {
+            logger.error("Invalid _timedOutState in saved run, falling back to init", {
+              _timedOutState: saved._timedOutState,
+            });
+            ctx.state = "init";
+          }
         }
       } else {
         const runId = `run-${Date.now()}-${randomUUID().slice(0, 8)}`;
@@ -369,7 +377,7 @@ export function createCli() {
               targetNumber: finalCtx.issueNumber ?? finalCtx.prNumber!,
               issueTitle: finalCtx.issueTitle,
               repo: finalCtx.repo,
-              finalState: finalCtx.state as "done" | "failed" | "blocked" | "manual_handoff",
+              finalState: finalCtx.state as TerminalState,
               elapsedMs,
               prNumber: finalCtx.prNumber,
             });
@@ -558,7 +566,7 @@ export function createCli() {
                     targetNumber: finalCtx.issueNumber ?? finalCtx.prNumber!,
                     issueTitle: finalCtx.issueTitle,
                     repo: finalCtx.repo,
-                    finalState: finalCtx.state as "done" | "failed" | "blocked" | "manual_handoff",
+                    finalState: finalCtx.state as TerminalState,
                     elapsedMs,
                     prNumber: finalCtx.prNumber,
                   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -544,6 +544,7 @@ export function createCli() {
             });
 
             await git.addWorktree(worktreePath, opts.base, cwd);
+            let preserveWorktree = false;
             try {
               const ctx: RunContext = {
                 runId,
@@ -567,7 +568,7 @@ export function createCli() {
               };
 
               const issueStart = performance.now();
-              await runWorkflow(ctx, handlers, persistence, {
+              const result = await runWorkflow(ctx, handlers, persistence, {
                 logger: runLogger,
                 onTransition: (from, to) =>
                   runLogger.info("State transition", { from, to }),
@@ -585,13 +586,26 @@ export function createCli() {
                   await slackNotify(message);
                 },
               });
+
+              if (result.state === "manual_handoff") {
+                preserveWorktree = true;
+                runLogger.warn("Issue handed off — worktree preserved for manual resume", {
+                  issue: issue.number,
+                  timedOutState: result._timedOutState,
+                  reason: result.handoffReason,
+                  worktreePath,
+                  resumeCommand: `aidev run --issue ${issue.number} --repo ${repo} --cwd ${cwd} --resume --yes`,
+                });
+              }
             } finally {
-              await git.removeWorktree(worktreePath, cwd).catch((err) =>
-                runLogger.error("Worktree cleanup failed", {
-                  path: worktreePath,
-                  error: String(err),
-                })
-              );
+              if (!preserveWorktree) {
+                await git.removeWorktree(worktreePath, cwd).catch((err) =>
+                  runLogger.error("Worktree cleanup failed", {
+                    path: worktreePath,
+                    error: String(err),
+                  })
+                );
+              }
             }
           };
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -202,6 +202,17 @@ export function createCli() {
             logger.warn("Resuming from manual_handoff with no _timedOutState, restarting from init");
             ctx.state = "init";
           }
+          // Clear handoff metadata to avoid stale data in the resumed run
+          delete ctx._timedOutState;
+          delete ctx.handoffReason;
+          // Clear stateTimeouts to prevent re-triggering the same timeout.
+          // User can re-specify via issue body if desired.
+          if (ctx.stateTimeouts) {
+            logger.info("Clearing stateTimeouts for resume to prevent repeated handoff", {
+              previousTimeouts: ctx.stateTimeouts,
+            });
+            delete ctx.stateTimeouts;
+          }
         }
       } else {
         const runId = `run-${Date.now()}-${randomUUID().slice(0, 8)}`;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ import { createSlackNotifier, formatSlackMessage } from "./adapters/slack.js";
 import { loadRepoConfig } from "./config/repo-config.js";
 import { writeAidevYml } from "./config/init.js";
 import { runPreflightChecks } from "./preflight.js";
-import { RunStateSchema, TERMINAL_STATES, type RunContext, type TerminalState } from "./types.js";
+import { RunStateSchema, TERMINAL_STATES, isTerminalState, type RunContext, type TerminalState } from "./types.js";
 import { formatElapsed, formatProgressEvent } from "./agents/shared.js";
 import { formatErrorDetails } from "./util/error.js";
 
@@ -332,7 +332,7 @@ export function createCli() {
 
       let exitCode = 0;
       let worktreeCreated = false;
-      let keepWorktree = false;
+      let resultState: string | undefined;
 
       // Determine whether to reuse existing worktree on resume.
       // Terminal states get a fresh worktree, except:
@@ -345,13 +345,22 @@ export function createCli() {
       try {
         if (shouldReuseWorktree) {
           if (!existsSync(worktreePath)) {
-            logger.error("Worktree not found for resume. The previous worktree may have been cleaned up.", { path: worktreePath });
-            await logger.flush();
-            process.exit(1);
+            // Worktree was deleted between handoff and resume (e.g. manual cleanup).
+            // Uncommitted work is lost — recreate worktree and restart from init.
+            logger.warn("Worktree not found for resume — recreating from scratch", {
+              path: worktreePath,
+              originalState: ctx.state,
+            });
+            await git.removeWorktree(worktreePath, originalCwd).catch(() => {});
+            await git.addWorktree(worktreePath, ctx.base, originalCwd);
+            ctx.state = "init";
+            ctx.cwd = worktreePath;
+            worktreeCreated = true;
+          } else {
+            ctx.cwd = worktreePath;
+            worktreeCreated = true;
+            logger.info("Reusing existing worktree for resume", { path: worktreePath });
           }
-          ctx.cwd = worktreePath;
-          worktreeCreated = true;
-          logger.info("Reusing existing worktree for resume", { path: worktreePath });
         } else {
           // Remove stale worktree from a previous interrupted run, if any
           await git.removeWorktree(worktreePath, originalCwd).catch(() => {});
@@ -378,13 +387,14 @@ export function createCli() {
             }
           },
           onComplete: async (finalCtx) => {
+            if (!isTerminalState(finalCtx.state)) return;
             const elapsedMs = Math.round(performance.now() - workflowStart);
             const message = formatSlackMessage({
               targetKind: finalCtx.targetKind,
               targetNumber: finalCtx.issueNumber ?? finalCtx.prNumber!,
               issueTitle: finalCtx.issueTitle,
               repo: finalCtx.repo,
-              finalState: finalCtx.state as TerminalState,
+              finalState: finalCtx.state,
               elapsedMs,
               prNumber: finalCtx.prNumber,
             });
@@ -404,7 +414,7 @@ export function createCli() {
           process.stdout.write(JSON.stringify(output) + "\n");
         } else if (result.state === "manual_handoff") {
           logger.warn("Devloop handed off - needs human intervention", { runId: ctx.runId });
-          keepWorktree = true;
+          resultState = result.state;
           const output = {
             status: "manual_handoff" as const,
             runId: result.runId,
@@ -444,7 +454,7 @@ export function createCli() {
         process.stdout.write(JSON.stringify(output) + "\n");
         exitCode = 1;
       } finally {
-        if (worktreeCreated && !keepWorktree) {
+        if (worktreeCreated && resultState !== "manual_handoff") {
           await git.removeWorktree(worktreePath, originalCwd).catch((err) =>
             logger.error("Worktree cleanup failed", {
               path: worktreePath,
@@ -452,7 +462,7 @@ export function createCli() {
             })
           );
         }
-        if (keepWorktree) {
+        if (resultState === "manual_handoff") {
           logger.info("Worktree preserved for resume", { path: worktreePath });
         }
       }
@@ -573,13 +583,14 @@ export function createCli() {
                 onTransition: (from, to) =>
                   runLogger.info("State transition", { from, to }),
                 onComplete: async (finalCtx) => {
+                  if (!isTerminalState(finalCtx.state)) return;
                   const elapsedMs = Math.round(performance.now() - issueStart);
                   const message = formatSlackMessage({
                     targetKind: finalCtx.targetKind,
                     targetNumber: finalCtx.issueNumber ?? finalCtx.prNumber!,
                     issueTitle: finalCtx.issueTitle,
                     repo: finalCtx.repo,
-                    finalState: finalCtx.state as TerminalState,
+                    finalState: finalCtx.state,
                     elapsedMs,
                     prNumber: finalCtx.prNumber,
                   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ import { createSlackNotifier, formatSlackMessage } from "./adapters/slack.js";
 import { loadRepoConfig } from "./config/repo-config.js";
 import { writeAidevYml } from "./config/init.js";
 import { runPreflightChecks } from "./preflight.js";
-import { RunStateSchema, type RunContext, type TerminalState } from "./types.js";
+import { RunStateSchema, TERMINAL_STATES, type RunContext, type TerminalState } from "./types.js";
 import { formatElapsed, formatProgressEvent } from "./agents/shared.js";
 import { formatErrorDetails } from "./util/error.js";
 
@@ -331,7 +331,7 @@ export function createCli() {
       // Determine whether to reuse existing worktree on resume.
       // Terminal states (done without dryRun, failed, blocked) get a fresh worktree.
       // Non-terminal states and done+dryRun (→creating_pr) need existing changes preserved.
-      const terminalStates = new Set(["done", "failed", "blocked"]);
+      const terminalStates = new Set<string>(TERMINAL_STATES);
       const shouldReuseWorktree = opts.resume
         && (!terminalStates.has(ctx.state) || (ctx.state === "done" && ctx.dryRun));
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -410,6 +410,7 @@ export function createCli() {
             runId: result.runId,
             timedOutState: result._timedOutState,
             reason: result.handoffReason,
+            worktreePath,
           };
           process.stdout.write(JSON.stringify(output) + "\n");
           exitCode = 1;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -332,10 +332,12 @@ export function createCli() {
 
       let exitCode = 0;
       let worktreeCreated = false;
+      let keepWorktree = false;
 
       // Determine whether to reuse existing worktree on resume.
-      // Terminal states (done without dryRun, failed, blocked) get a fresh worktree.
-      // Non-terminal states and done+dryRun (→creating_pr) need existing changes preserved.
+      // Terminal states get a fresh worktree, except:
+      // - done+dryRun (→creating_pr): needs existing changes preserved
+      // - manual_handoff resume: state changed to _timedOutState, needs worktree
       const terminalStates = new Set<string>(TERMINAL_STATES);
       const shouldReuseWorktree = opts.resume
         && (!terminalStates.has(ctx.state) || (ctx.state === "done" && ctx.dryRun));
@@ -402,6 +404,7 @@ export function createCli() {
           process.stdout.write(JSON.stringify(output) + "\n");
         } else if (result.state === "manual_handoff") {
           logger.warn("Devloop handed off - needs human intervention", { runId: ctx.runId });
+          keepWorktree = true;
           const output = {
             status: "manual_handoff" as const,
             runId: result.runId,
@@ -440,13 +443,16 @@ export function createCli() {
         process.stdout.write(JSON.stringify(output) + "\n");
         exitCode = 1;
       } finally {
-        if (worktreeCreated) {
+        if (worktreeCreated && !keepWorktree) {
           await git.removeWorktree(worktreePath, originalCwd).catch((err) =>
             logger.error("Worktree cleanup failed", {
               path: worktreePath,
               error: String(err),
             })
           );
+        }
+        if (keepWorktree) {
+          logger.info("Worktree preserved for resume", { path: worktreePath });
         }
       }
       if (exitCode !== 0) {

--- a/src/config/issue-config.ts
+++ b/src/config/issue-config.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { SkippableStateSchema, LanguageSchema } from "../types.js";
-import type { SkippableState, Language } from "../types.js";
+import { SkippableStateSchema, LanguageSchema, RunStateSchema } from "../types.js";
+import type { SkippableState, Language, RunState } from "../types.js";
 
 export type { SkippableState, Language } from "../types.js";
 export { LanguageSchema } from "../types.js";
@@ -16,6 +16,7 @@ const IssueConfigSchema = z
     backend: z.string().optional(),
     model: z.string().optional(),
     language: LanguageSchema.optional(),
+    stateTimeouts: z.record(RunStateSchema, z.number()).optional(),
   })
   .strict();
 
@@ -31,6 +32,7 @@ export interface ResolvedConfig {
   backend?: string;
   model?: string;
   language: Language;
+  stateTimeouts?: Partial<Record<RunState, number>>;
 }
 
 /**
@@ -49,50 +51,61 @@ function extractAidevBlock(body: string): string | null {
  *     - item
  *   # comment lines (skipped)
  */
-function parseYamlLike(block: string): Record<string, string | string[]> {
-  const result: Record<string, string | string[]> = {};
+function parseYamlLike(block: string): Record<string, string | string[] | Record<string, string>> {
+  const result: Record<string, string | string[] | Record<string, string>> = {};
   const lines = block.split("\n");
   let currentKey: string | null = null;
   let currentList: string[] | null = null;
+  let currentMap: Record<string, string> | null = null;
+
+  function flushCurrent() {
+    if (currentKey) {
+      if (currentList && currentList.length > 0) result[currentKey] = currentList;
+      if (currentMap && Object.keys(currentMap).length > 0) result[currentKey] = currentMap;
+    }
+    currentKey = null;
+    currentList = null;
+    currentMap = null;
+  }
 
   for (const rawLine of lines) {
     const line = rawLine.trim();
     if (!line) continue;
     if (line.startsWith("#")) continue;
 
-    const listItem = line.match(/^-\s+(.+)$/);
-    if (listItem && currentKey) {
-      if (!currentList) currentList = [];
-      currentList.push(listItem[1]!.trim());
-      continue;
+    const isIndented = /^\s+/.test(rawLine);
+
+    if (isIndented && currentKey) {
+      const listItem = line.match(/^-\s+(.+)$/);
+      if (listItem) {
+        if (!currentList) currentList = [];
+        currentList.push(listItem[1]!.trim());
+        continue;
+      }
+
+      const nestedKv = line.match(/^(\w+)\s*:\s*(.+)$/);
+      if (nestedKv) {
+        if (!currentMap) currentMap = {};
+        currentMap[nestedKv[1]!] = nestedKv[2]!.trim();
+        continue;
+      }
     }
 
-    // Flush previous list
-    if (currentKey && currentList) {
-      result[currentKey] = currentList;
-      currentKey = null;
-      currentList = null;
-    }
+    flushCurrent();
 
     const kv = line.match(/^(\w+)\s*:\s*(.*)$/);
     if (kv) {
       const key = kv[1]!;
       const value = kv[2]!.trim();
       if (value === "") {
-        // Start of a list
         currentKey = key;
-        currentList = [];
       } else {
         result[key] = value;
       }
     }
   }
 
-  // Flush final list
-  if (currentKey && currentList) {
-    result[currentKey] = currentList;
-  }
-
+  flushCurrent();
   return result;
 }
 
@@ -156,6 +169,19 @@ export function parseConfigBlock(block: string): Partial<IssueConfig> {
       (s) => SkippableStateSchema.safeParse(s).success
     );
     if (valid.length > 0) obj.skip = valid;
+  }
+
+  if (raw.stateTimeouts && typeof raw.stateTimeouts === "object" && !Array.isArray(raw.stateTimeouts)) {
+    const map = raw.stateTimeouts as Record<string, string>;
+    const timeouts: Partial<Record<RunState, number>> = {};
+    for (const [key, val] of Object.entries(map)) {
+      if (!RunStateSchema.safeParse(key).success) continue;
+      const n = Number(val);
+      if (Number.isFinite(n) && n > 0) {
+        timeouts[key as RunState] = n;
+      }
+    }
+    if (Object.keys(timeouts).length > 0) obj.stateTimeouts = timeouts;
   }
 
   return obj;

--- a/src/config/issue-config.ts
+++ b/src/config/issue-config.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { SkippableStateSchema, LanguageSchema, RunStateSchema } from "../types.js";
 import type { SkippableState, Language, RunState } from "../types.js";
-import { MIN_STATE_TIMEOUT_MS } from "../workflow/engine.js";
+import { MIN_STATE_TIMEOUT_MS, MAX_STATE_TIMEOUT_MS } from "../workflow/engine.js";
 
 export type { SkippableState, Language } from "../types.js";
 export { LanguageSchema } from "../types.js";
@@ -154,7 +154,10 @@ export function parseConfigBlock(block: string): Partial<IssueConfig> {
   }
 
   if (typeof raw.base === "string" && raw.base.length > 0) {
-    obj.base = raw.base;
+    // Only allow branch-name-safe characters; reject path traversal
+    if (/^[a-zA-Z0-9._\-/]+$/.test(raw.base) && !raw.base.includes("..")) {
+      obj.base = raw.base;
+    }
   }
 
   if (typeof raw.backend === "string" && raw.backend.length > 0) {
@@ -182,7 +185,7 @@ export function parseConfigBlock(block: string): Partial<IssueConfig> {
     for (const [key, val] of Object.entries(map)) {
       if (!RunStateSchema.safeParse(key).success) continue;
       const n = Number(val);
-      if (Number.isFinite(n) && n >= MIN_STATE_TIMEOUT_MS) {
+      if (Number.isFinite(n) && n >= MIN_STATE_TIMEOUT_MS && n <= MAX_STATE_TIMEOUT_MS) {
         timeouts[key as RunState] = n;
       }
     }

--- a/src/config/issue-config.ts
+++ b/src/config/issue-config.ts
@@ -61,7 +61,7 @@ function parseYamlLike(block: string): Record<string, string | string[] | Record
   function flushCurrent() {
     if (currentKey) {
       if (currentList && currentList.length > 0) result[currentKey] = currentList;
-      if (currentMap && Object.keys(currentMap).length > 0) result[currentKey] = currentMap;
+      else if (currentMap && Object.keys(currentMap).length > 0) result[currentKey] = currentMap;
     }
     currentKey = null;
     currentList = null;

--- a/src/config/issue-config.ts
+++ b/src/config/issue-config.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { SkippableStateSchema, LanguageSchema, RunStateSchema } from "../types.js";
 import type { SkippableState, Language, RunState } from "../types.js";
+import { MIN_STATE_TIMEOUT_MS } from "../workflow/engine.js";
 
 export type { SkippableState, Language } from "../types.js";
 export { LanguageSchema } from "../types.js";
@@ -60,6 +61,10 @@ function parseYamlLike(block: string): Record<string, string | string[] | Record
 
   function flushCurrent() {
     if (currentKey) {
+      // List items (- item) and map items (key: value) under the same key are
+      // mutually exclusive. If both are present (malformed input), list wins
+      // and map entries are silently discarded. This is intentional — our
+      // config format doesn't support mixed nested structures.
       if (currentList && currentList.length > 0) result[currentKey] = currentList;
       else if (currentMap && Object.keys(currentMap).length > 0) result[currentKey] = currentMap;
     }
@@ -177,7 +182,7 @@ export function parseConfigBlock(block: string): Partial<IssueConfig> {
     for (const [key, val] of Object.entries(map)) {
       if (!RunStateSchema.safeParse(key).success) continue;
       const n = Number(val);
-      if (Number.isFinite(n) && n > 0) {
+      if (Number.isFinite(n) && n >= MIN_STATE_TIMEOUT_MS) {
         timeouts[key as RunState] = n;
       }
     }

--- a/src/config/merge-config.ts
+++ b/src/config/merge-config.ts
@@ -7,6 +7,11 @@ export function mergeConfigs(
 ): Partial<IssueConfig> {
   const merged = { ...repoConfig, ...issueConfig };
 
+  // Deep-merge stateTimeouts (object, not scalar)
+  if (repoConfig.stateTimeouts && issueConfig.stateTimeouts) {
+    merged.stateTimeouts = { ...repoConfig.stateTimeouts, ...issueConfig.stateTimeouts };
+  }
+
   for (const key of cliExplicit) {
     delete merged[key as keyof IssueConfig];
   }

--- a/src/config/serialize-config.ts
+++ b/src/config/serialize-config.ts
@@ -24,6 +24,13 @@ export function serializeConfig(config: ResolvedConfig): string {
     }
   }
 
+  if (config.stateTimeouts && Object.keys(config.stateTimeouts).length > 0) {
+    lines.push("stateTimeouts:");
+    for (const [state, ms] of Object.entries(config.stateTimeouts)) {
+      lines.push(`  ${state}: ${ms}`);
+    }
+  }
+
   return lines.join("\n");
 }
 

--- a/src/config/serialize-config.ts
+++ b/src/config/serialize-config.ts
@@ -26,7 +26,7 @@ export function serializeConfig(config: ResolvedConfig): string {
 
   if (config.stateTimeouts && Object.keys(config.stateTimeouts).length > 0) {
     lines.push("stateTimeouts:");
-    for (const [state, ms] of Object.entries(config.stateTimeouts)) {
+    for (const [state, ms] of Object.entries(config.stateTimeouts).sort(([a], [b]) => a.localeCompare(b))) {
       lines.push(`  ${state}: ${ms}`);
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export const RunStateSchema = z.enum([
   "done",
   "failed",
   "blocked",
+  "manual_handoff",
 ]);
 export type RunState = z.infer<typeof RunStateSchema>;
 
@@ -89,6 +90,9 @@ export const RunContextSchema = z.object({
   review: ReviewSchema.optional(),
   fix: FixSchema.optional(),
   fixTrigger: z.enum(["ci", "review"]).optional(),
+  handoffReason: z.string().optional(),
+  _timedOutState: RunStateSchema.optional(),
+  stateTimeouts: z.record(RunStateSchema, z.number()).optional(),
 }).superRefine((ctx, issueCtx) => {
   if (ctx.targetKind === "issue" && ctx.issueNumber == null) {
     issueCtx.addIssue({

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,8 @@ export const RunStateSchema = z.enum([
 ]);
 export type RunState = z.infer<typeof RunStateSchema>;
 
-export type TerminalState = "done" | "failed" | "blocked" | "manual_handoff";
+export const TERMINAL_STATES = ["done", "failed", "blocked", "manual_handoff"] as const;
+export type TerminalState = (typeof TERMINAL_STATES)[number];
 
 export const PlanSchema = z.object({
   summary: z.string(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,8 @@ export const RunStateSchema = z.enum([
 ]);
 export type RunState = z.infer<typeof RunStateSchema>;
 
+export type TerminalState = "done" | "failed" | "blocked" | "manual_handoff";
+
 export const PlanSchema = z.object({
   summary: z.string(),
   steps: z.array(z.string()).min(1),

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,8 +27,13 @@ export const RunStateSchema = z.enum([
 ]);
 export type RunState = z.infer<typeof RunStateSchema>;
 
-export const TERMINAL_STATES = ["done", "failed", "blocked", "manual_handoff"] as const;
+export const TERMINAL_STATES = ["done", "failed", "blocked", "manual_handoff"] as const satisfies readonly RunState[];
 export type TerminalState = (typeof TERMINAL_STATES)[number];
+
+/** Type guard: narrows RunState to TerminalState */
+export function isTerminalState(state: RunState): state is TerminalState {
+  return (TERMINAL_STATES as readonly string[]).includes(state);
+}
 
 export const PlanSchema = z.object({
   summary: z.string(),
@@ -115,6 +120,17 @@ export const RunContextSchema = z.object({
 export type RunContext = z.infer<typeof RunContextSchema> & {
   /** Set of CLI flags explicitly specified (transient, not persisted) */
   _cliExplicit?: Set<string>;
+  /**
+   * Abort signal injected by `withTimeout`. Handlers should check
+   * `ctx._abortSignal?.aborted` before starting expensive operations
+   * (e.g. spawning child processes, AI API calls) and pass the signal
+   * to cancellable APIs where possible.
+   *
+   * NOTE: Cancellation is cooperative — aborting the signal does not
+   * forcibly terminate the handler. If the handler ignores the signal,
+   * it will continue running in the background after timeout.
+   */
+  _abortSignal?: AbortSignal;
 };
 
 export type StateHandler = (

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -78,6 +78,11 @@ export function createLogger(opts: CreateLoggerOptions = {}): Logger {
     setLogFile(path: string) {
       openStream(path);
     },
+    /**
+     * Flush pending writes and close the underlying file stream.
+     * After calling this method the logger can no longer write to the log file.
+     * Intended to be called once, immediately before process exit.
+     */
     flush(): Promise<void> {
       return new Promise((resolve) => {
         if (stream && !stream.destroyed && !stream.writableEnded) {

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -79,12 +79,10 @@ export function createLogger(opts: CreateLoggerOptions = {}): Logger {
       openStream(path);
     },
     flush(): Promise<void> {
-      return new Promise((resolve, reject) => {
-        if (stream && !stream.destroyed) {
-          stream.write("", (err) => {
-            if (err) reject(err);
-            else resolve();
-          });
+      return new Promise((resolve) => {
+        if (stream && !stream.destroyed && !stream.writableEnded) {
+          stream.once("finish", resolve);
+          stream.end();
         } else {
           resolve();
         }

--- a/src/workflow/engine.ts
+++ b/src/workflow/engine.ts
@@ -31,7 +31,7 @@ export function withTimeout(
   timeoutMs: number,
   logger?: Logger,
 ): StateHandler {
-  if (!Number.isFinite(timeoutMs)) return handler;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return handler;
 
   return (ctx) => {
     return new Promise<{ nextState: RunState; ctx: RunContext }>((resolve, reject) => {

--- a/src/workflow/engine.ts
+++ b/src/workflow/engine.ts
@@ -127,6 +127,13 @@ export async function runWorkflow(
     const timeoutMs = ctx.stateTimeouts?.[ctx.state];
     if (timeoutMs != null && timeoutMs >= MIN_STATE_TIMEOUT_MS) {
       const clampedMs = Math.min(timeoutMs, MAX_STATE_TIMEOUT_MS);
+      if (clampedMs < timeoutMs) {
+        logger?.warn(`stateTimeouts.${ctx.state} exceeds maximum — clamped from ${timeoutMs}ms to ${MAX_STATE_TIMEOUT_MS}ms`, {
+          state: ctx.state,
+          configured: timeoutMs,
+          clamped: MAX_STATE_TIMEOUT_MS,
+        });
+      }
       handler = withTimeout(handler, clampedMs, logger);
     }
 

--- a/src/workflow/engine.ts
+++ b/src/workflow/engine.ts
@@ -17,7 +17,42 @@ export interface WorkflowOptions {
   logger?: Logger;
 }
 
-const terminalStates: ReadonlySet<RunState> = new Set(["done", "failed", "blocked"]);
+const terminalStates: ReadonlySet<RunState> = new Set(["done", "failed", "blocked", "manual_handoff"]);
+
+/**
+ * Wrap a StateHandler with a wall-clock timeout.
+ * If the handler doesn't complete within `timeoutMs`, the workflow transitions
+ * to `manual_handoff` with `_timedOutState` set to the current state.
+ * Pass `Infinity` to effectively disable the timeout.
+ */
+export function withTimeout(
+  handler: StateHandler,
+  timeoutMs: number,
+  logger?: Logger,
+): StateHandler {
+  if (!Number.isFinite(timeoutMs)) return handler;
+
+  return async (ctx) => {
+    const timeout = new Promise<{ nextState: RunState; ctx: RunContext }>((resolve) => {
+      setTimeout(() => {
+        logger?.warn(`State ${ctx.state} timed out after ${timeoutMs}ms — handing off`, {
+          state: ctx.state,
+          timeoutMs,
+        });
+        resolve({
+          nextState: "manual_handoff",
+          ctx: {
+            ...ctx,
+            _timedOutState: ctx.state,
+            handoffReason: `State ${ctx.state} timed out after ${timeoutMs}ms`,
+          },
+        });
+      }, timeoutMs);
+    });
+
+    return Promise.race([handler(ctx), timeout]);
+  };
+}
 
 export async function runWorkflow(
   initial: RunContext,

--- a/src/workflow/engine.ts
+++ b/src/workflow/engine.ts
@@ -27,6 +27,12 @@ const terminalStates: ReadonlySet<RunState> = new Set(TERMINAL_STATES);
 export const MIN_STATE_TIMEOUT_MS = 5_000;
 
 /**
+ * Maximum allowed state timeout (1 hour). Values above this are clamped
+ * to prevent unbounded resource holds from malicious issue body config.
+ */
+export const MAX_STATE_TIMEOUT_MS = 60 * 60 * 1000;
+
+/**
  * Wrap a StateHandler with a wall-clock timeout and cooperative cancellation.
  *
  * When the timeout fires:

--- a/src/workflow/engine.ts
+++ b/src/workflow/engine.ts
@@ -71,10 +71,25 @@ export function withTimeout(
       handler(ctxWithSignal).then(
         (result) => {
           clearTimeout(timer);
+          if (ac.signal.aborted) {
+            // Handler completed after timeout — result is discarded but log for debugging
+            logger?.warn(`State ${ctx.state} handler completed after timeout (result discarded)`, {
+              state: ctx.state,
+              handlerNextState: result.nextState,
+            });
+            return; // resolve() already called by timer
+          }
           resolve(result);
         },
         (err) => {
           clearTimeout(timer);
+          if (ac.signal.aborted) {
+            logger?.warn(`State ${ctx.state} handler failed after timeout (error discarded)`, {
+              state: ctx.state,
+              error: String(err),
+            });
+            return; // resolve() already called by timer
+          }
           reject(err);
         },
       );
@@ -98,9 +113,9 @@ export async function runWorkflow(
       throw new Error(`No handler for state: ${ctx.state}`);
     }
 
-    // Apply per-state timeout if configured
+    // Apply per-state timeout if configured (enforce minimum as defense in depth)
     const timeoutMs = ctx.stateTimeouts?.[ctx.state];
-    if (timeoutMs != null) {
+    if (timeoutMs != null && timeoutMs >= MIN_STATE_TIMEOUT_MS) {
       handler = withTimeout(handler, timeoutMs, logger);
     }
 
@@ -131,8 +146,8 @@ export async function runWorkflow(
 
   try {
     await options?.onComplete?.(ctx);
-  } catch {
-    logger?.warn("onComplete callback failed");
+  } catch (err) {
+    logger?.warn("onComplete callback failed", { ...formatErrorDetails(err) });
   }
 
   return ctx;

--- a/src/workflow/engine.ts
+++ b/src/workflow/engine.ts
@@ -119,10 +119,11 @@ export async function runWorkflow(
       throw new Error(`No handler for state: ${ctx.state}`);
     }
 
-    // Apply per-state timeout if configured (enforce minimum as defense in depth)
+    // Apply per-state timeout if configured (enforce min/max as defense in depth)
     const timeoutMs = ctx.stateTimeouts?.[ctx.state];
     if (timeoutMs != null && timeoutMs >= MIN_STATE_TIMEOUT_MS) {
-      handler = withTimeout(handler, timeoutMs, logger);
+      const clampedMs = Math.min(timeoutMs, MAX_STATE_TIMEOUT_MS);
+      handler = withTimeout(handler, clampedMs, logger);
     }
 
     const from = ctx.state;
@@ -144,7 +145,16 @@ export async function runWorkflow(
     options?.onTransition?.(from, nextState, elapsedMs);
 
     ctx = { ...nextCtx, state: nextState };
-    await persistence.save(ctx);
+    try {
+      await persistence.save(ctx);
+    } catch (saveErr) {
+      logger?.error("Failed to persist state — halting to prevent state divergence", {
+        state: ctx.state,
+        runId: ctx.runId,
+        ...formatErrorDetails(saveErr),
+      });
+      throw saveErr;
+    }
   }
 
   const totalElapsedMs = Math.round(performance.now() - workflowStart);

--- a/src/workflow/engine.ts
+++ b/src/workflow/engine.ts
@@ -24,7 +24,7 @@ const terminalStates: ReadonlySet<RunState> = new Set(TERMINAL_STATES);
  * Wrap a StateHandler with a wall-clock timeout.
  * If the handler doesn't complete within `timeoutMs`, the workflow transitions
  * to `manual_handoff` with `_timedOutState` set to the current state.
- * Pass `Infinity` to effectively disable the timeout.
+ * Pass `Infinity` or a non-positive value to effectively disable the timeout.
  */
 export function withTimeout(
   handler: StateHandler,

--- a/src/workflow/engine.ts
+++ b/src/workflow/engine.ts
@@ -1,3 +1,4 @@
+import { TERMINAL_STATES } from "../types.js";
 import type { RunContext, RunState, StateHandler } from "../types.js";
 import type { Logger } from "../util/logger.js";
 import { formatErrorDetails } from "../util/error.js";
@@ -17,7 +18,7 @@ export interface WorkflowOptions {
   logger?: Logger;
 }
 
-const terminalStates: ReadonlySet<RunState> = new Set(["done", "failed", "blocked", "manual_handoff"]);
+const terminalStates: ReadonlySet<RunState> = new Set(TERMINAL_STATES);
 
 /**
  * Wrap a StateHandler with a wall-clock timeout.
@@ -33,7 +34,7 @@ export function withTimeout(
   if (!Number.isFinite(timeoutMs)) return handler;
 
   return (ctx) => {
-    return new Promise<{ nextState: RunState; ctx: RunContext }>((resolve) => {
+    return new Promise<{ nextState: RunState; ctx: RunContext }>((resolve, reject) => {
       const timer = setTimeout(() => {
         logger?.warn(`State ${ctx.state} timed out after ${timeoutMs}ms — handing off`, {
           state: ctx.state,
@@ -49,10 +50,16 @@ export function withTimeout(
         });
       }, timeoutMs);
 
-      handler(ctx).then((result) => {
-        clearTimeout(timer);
-        resolve(result);
-      });
+      handler(ctx).then(
+        (result) => {
+          clearTimeout(timer);
+          resolve(result);
+        },
+        (err) => {
+          clearTimeout(timer);
+          reject(err);
+        },
+      );
     });
   };
 }

--- a/src/workflow/engine.ts
+++ b/src/workflow/engine.ts
@@ -21,9 +21,23 @@ export interface WorkflowOptions {
 const terminalStates: ReadonlySet<RunState> = new Set(TERMINAL_STATES);
 
 /**
- * Wrap a StateHandler with a wall-clock timeout.
- * If the handler doesn't complete within `timeoutMs`, the workflow transitions
- * to `manual_handoff` with `_timedOutState` set to the current state.
+ * Minimum allowed state timeout. Values below this threshold are rejected
+ * to prevent accidental instant timeouts (e.g. from malicious issue body config).
+ */
+export const MIN_STATE_TIMEOUT_MS = 5_000;
+
+/**
+ * Wrap a StateHandler with a wall-clock timeout and cooperative cancellation.
+ *
+ * When the timeout fires:
+ * 1. An `AbortSignal` injected into `ctx._abortSignal` is aborted.
+ * 2. The workflow transitions to `manual_handoff`.
+ *
+ * **Important**: Cancellation is cooperative. The handler continues running
+ * in the background after timeout unless it checks `ctx._abortSignal?.aborted`
+ * and terminates early. Callers should propagate the signal to child processes
+ * and cancellable APIs (e.g. `fetch(url, { signal })`) where possible.
+ *
  * Pass `Infinity` or a non-positive value to effectively disable the timeout.
  */
 export function withTimeout(
@@ -34,8 +48,12 @@ export function withTimeout(
   if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return handler;
 
   return (ctx) => {
+    const ac = new AbortController();
+    const ctxWithSignal = { ...ctx, _abortSignal: ac.signal };
+
     return new Promise<{ nextState: RunState; ctx: RunContext }>((resolve, reject) => {
       const timer = setTimeout(() => {
+        ac.abort();
         logger?.warn(`State ${ctx.state} timed out after ${timeoutMs}ms — handing off`, {
           state: ctx.state,
           timeoutMs,
@@ -50,7 +68,7 @@ export function withTimeout(
         });
       }, timeoutMs);
 
-      handler(ctx).then(
+      handler(ctxWithSignal).then(
         (result) => {
           clearTimeout(timer);
           resolve(result);

--- a/src/workflow/engine.ts
+++ b/src/workflow/engine.ts
@@ -32,9 +32,9 @@ export function withTimeout(
 ): StateHandler {
   if (!Number.isFinite(timeoutMs)) return handler;
 
-  return async (ctx) => {
-    const timeout = new Promise<{ nextState: RunState; ctx: RunContext }>((resolve) => {
-      setTimeout(() => {
+  return (ctx) => {
+    return new Promise<{ nextState: RunState; ctx: RunContext }>((resolve) => {
+      const timer = setTimeout(() => {
         logger?.warn(`State ${ctx.state} timed out after ${timeoutMs}ms — handing off`, {
           state: ctx.state,
           timeoutMs,
@@ -48,9 +48,12 @@ export function withTimeout(
           },
         });
       }, timeoutMs);
-    });
 
-    return Promise.race([handler(ctx), timeout]);
+      handler(ctx).then((result) => {
+        clearTimeout(timer);
+        resolve(result);
+      });
+    });
   };
 }
 
@@ -65,9 +68,15 @@ export async function runWorkflow(
   const workflowStart = performance.now();
 
   while (!terminalStates.has(ctx.state)) {
-    const handler = handlers[ctx.state];
+    let handler = handlers[ctx.state];
     if (!handler) {
       throw new Error(`No handler for state: ${ctx.state}`);
+    }
+
+    // Apply per-state timeout if configured
+    const timeoutMs = ctx.stateTimeouts?.[ctx.state];
+    if (timeoutMs != null) {
+      handler = withTimeout(handler, timeoutMs, logger);
     }
 
     const from = ctx.state;

--- a/src/workflow/engine.ts
+++ b/src/workflow/engine.ts
@@ -45,6 +45,10 @@ export const MAX_STATE_TIMEOUT_MS = 60 * 60 * 1000;
  * and cancellable APIs (e.g. `fetch(url, { signal })`) where possible.
  *
  * Pass `Infinity` or a non-positive value to effectively disable the timeout.
+ *
+ * **NOTE**: This function does NOT enforce `MIN_STATE_TIMEOUT_MS`. The engine's
+ * `runWorkflow` applies min/max guards before calling this. Direct callers
+ * (e.g. tests) bypass those guards and must enforce their own minimum.
  */
 export function withTimeout(
   handler: StateHandler,

--- a/src/workflow/states.ts
+++ b/src/workflow/states.ts
@@ -187,6 +187,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
       backend: merged.backend,
       model: merged.model,
       language: mergedCtx.language,
+      stateTimeouts: mergedCtx.stateTimeouts,
     };
     const configBlock = buildResolvedConfigBlock(resolvedConfig);
     const updatedBody = upsertAidevBlock(body, configBlock);

--- a/src/workflow/states.ts
+++ b/src/workflow/states.ts
@@ -410,8 +410,15 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
     const pollInterval = 15 * 1000; // 15 seconds
     const gracePeriod = 30 * 1000; // 30 seconds for CI check runs to register
     const start = Date.now();
+    const signal = ctx._abortSignal;
 
     while (Date.now() - start < maxWait) {
+      if (signal?.aborted) {
+        logger.info("watching_ci aborted by timeout signal");
+        return transition(ctx, "manual_handoff", {
+          handoffReason: "watching_ci aborted by timeout",
+        });
+      }
       const status = await github.getCiStatus(ctx.branch);
       if (status === "passing") {
         logger.info("CI passed");
@@ -434,7 +441,11 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
         if (!shouldAutoMerge(ctx)) return transition(ctx, "done");
         return transition(ctx, "merging");
       }
-      await new Promise((r) => setTimeout(r, pollInterval));
+      // Abort-aware sleep: wake up early if timeout signal fires
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, pollInterval);
+        signal?.addEventListener("abort", () => { clearTimeout(timer); resolve(); }, { once: true });
+      });
     }
 
     logger.error("CI timed out");

--- a/src/workflow/states.ts
+++ b/src/workflow/states.ts
@@ -208,7 +208,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
         const authenticatedUser = await github.getAuthenticatedUser();
         if (pr.author !== authenticatedUser) {
           throw new Error(
-            `PR #${pr.number} was not created by the authenticated user. Use --allow-foreign-issues to bypass this check.`
+            `PR #${pr.number} was created by '${pr.author}', not by the authenticated user '${authenticatedUser}'. Use --allow-foreign-issues to bypass this check.`
           );
         }
       }
@@ -246,7 +246,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
       const authenticatedUser = await github.getAuthenticatedUser();
       if (issue.author !== authenticatedUser) {
         throw new Error(
-          `Issue #${issue.number} was not created by the authenticated user. Use --allow-foreign-issues to bypass this check.`
+          `Issue #${issue.number} was created by '${issue.author}', not by the authenticated user '${authenticatedUser}'. Use --allow-foreign-issues to bypass this check.`
         );
       }
     }
@@ -454,7 +454,6 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
       await new Promise<void>((resolve) => {
         const onAbort = () => { clearTimeout(timer); resolve(); };
         const timer = setTimeout(() => {
-          signal?.removeEventListener("abort", onAbort);
           resolve();
         }, pollInterval);
         signal?.addEventListener("abort", onAbort, { once: true });

--- a/src/workflow/states.ts
+++ b/src/workflow/states.ts
@@ -208,7 +208,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
         const authenticatedUser = await github.getAuthenticatedUser();
         if (pr.author !== authenticatedUser) {
           throw new Error(
-            `PR #${pr.number} was created by '${pr.author}', not by the authenticated user '${authenticatedUser}'. Use --allow-foreign-issues to bypass this check.`
+            `PR #${pr.number} was not created by the authenticated user. Use --allow-foreign-issues to bypass this check.`
           );
         }
       }
@@ -246,7 +246,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
       const authenticatedUser = await github.getAuthenticatedUser();
       if (issue.author !== authenticatedUser) {
         throw new Error(
-          `Issue #${issue.number} was created by '${issue.author}', not by the authenticated user '${authenticatedUser}'. Use --allow-foreign-issues to bypass this check.`
+          `Issue #${issue.number} was not created by the authenticated user. Use --allow-foreign-issues to bypass this check.`
         );
       }
     }
@@ -266,6 +266,9 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
   };
 
   const planning: StateHandler = async (ctx) => {
+    if (ctx._abortSignal?.aborted) {
+      return transition(ctx, "manual_handoff", { handoffReason: "planning aborted before start" });
+    }
     const workItem =
       ctx.targetKind === "pr"
         ? toPlanningTarget(await github.getPr(ctx.prNumber!))
@@ -293,6 +296,9 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
 
   const implementing: StateHandler = async (ctx) => {
     if (!ctx.plan) throw new Error("No plan available");
+    if (ctx._abortSignal?.aborted) {
+      return transition(ctx, "manual_handoff", { handoffReason: "implementing aborted before start" });
+    }
     const implStart = performance.now();
     const result = await runImplementer(
       {
@@ -320,6 +326,9 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
       return transition(ctx, "watching_ci");
     }
     if (!ctx.plan) throw new Error("No plan available");
+    if (ctx._abortSignal?.aborted) {
+      return transition(ctx, "manual_handoff", { handoffReason: "reviewing aborted before start" });
+    }
     const diff = await git.diff(ctx.base, ctx.cwd);
     const currentRound = (ctx.reviewRound ?? 0) + 1;
     const maxRounds = ctx.maxReviewRounds ?? 1;
@@ -443,8 +452,12 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
       }
       // Abort-aware sleep: wake up early if timeout signal fires
       await new Promise<void>((resolve) => {
-        const timer = setTimeout(resolve, pollInterval);
-        signal?.addEventListener("abort", () => { clearTimeout(timer); resolve(); }, { once: true });
+        const onAbort = () => { clearTimeout(timer); resolve(); };
+        const timer = setTimeout(() => {
+          signal?.removeEventListener("abort", onAbort);
+          resolve();
+        }, pollInterval);
+        signal?.addEventListener("abort", onAbort, { once: true });
       });
     }
 
@@ -454,6 +467,9 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
 
   const fixing: StateHandler = async (ctx) => {
     if (!ctx.plan) throw new Error("No plan available");
+    if (ctx._abortSignal?.aborted) {
+      return transition(ctx, "manual_handoff", { handoffReason: "fixing aborted before start" });
+    }
     const isReviewFix = ctx.fixTrigger === "review";
     const fixerInput = isReviewFix
       ? { plan: ctx.plan, reviewFeedback: ctx.review!.mustFix.join("\n"), cwd: ctx.cwd }
@@ -467,6 +483,12 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
     );
     const fixElapsed = Math.round(performance.now() - fixStart);
     logger.info("Fix applied", { rootCause: fix.rootCause, trigger: ctx.fixTrigger ?? "ci", agentElapsedMs: fixElapsed });
+
+    // Check abort signal before git operations to prevent ghost commits after timeout
+    if (ctx._abortSignal?.aborted) {
+      logger.warn("fixing: agent completed but abort signal fired — skipping git commit/push");
+      return transition(ctx, "manual_handoff", { handoffReason: "fixing aborted after agent completion" });
+    }
 
     await git.addAll(ctx.cwd);
     await git.commit(`fix: ${fix.rootCause}`, ctx.cwd);

--- a/src/workflow/states.ts
+++ b/src/workflow/states.ts
@@ -1,4 +1,5 @@
 import type { AgentRunner, ProgressEvent } from "../agents/runner.js";
+import { TERMINAL_STATES } from "../types.js";
 import type { StateHandler, RunContext, RunState, Review, Language } from "../types.js";
 import type { StateHandlerMap } from "./engine.js";
 import type { GitAdapter } from "../adapters/git.js";
@@ -43,7 +44,7 @@ function toPlanningTarget(workItem: Issue | PullRequest): Issue {
   };
 }
 
-const terminalStates: ReadonlySet<RunState> = new Set(["done", "failed", "blocked"]);
+const terminalStates: ReadonlySet<RunState> = new Set(TERMINAL_STATES);
 
 function formatReviewComment(review: Review, round: number, maxRounds: number, language: Language): string {
   const safeMaxRounds = maxRounds ?? 1;
@@ -158,6 +159,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
     if (merged.base !== undefined) patch.base = merged.base;
     if (merged.skip) patch.skipStates = merged.skip as SkippableState[];
     if (merged.language !== undefined) patch.language = merged.language;
+    if (merged.stateTimeouts !== undefined) patch.stateTimeouts = merged.stateTimeouts;
 
     // Re-create runner if backend/model changed via config
     if (merged.backend || merged.model) {

--- a/test/adapters/slack.test.ts
+++ b/test/adapters/slack.test.ts
@@ -66,6 +66,13 @@ describe("formatSlackMessage", () => {
     const msg = formatSlackMessage({ ...baseInput, issueTitle: undefined });
     expect(msg).toContain("Issue #42");
   });
+
+  it("formats a manual_handoff message with raised_hand icon", () => {
+    const msg = formatSlackMessage({ ...baseInput, finalState: "manual_handoff" });
+    expect(msg).toContain(":raised_hand:");
+    expect(msg).toContain("handed off");
+    expect(msg).toContain("#42");
+  });
 });
 
 describe("createSlackNotifier", () => {

--- a/test/cli-watch.test.ts
+++ b/test/cli-watch.test.ts
@@ -207,6 +207,110 @@ describe("watch command", () => {
     // The watcher should still be alive (no throw)
   });
 
+  it("preserves worktree when watch mode issue ends in manual_handoff", async () => {
+    const mockGithub = {
+      listIssuesByLabel: vi.fn(async () => [
+        { number: 55, title: "Timeout issue", body: "body", labels: ["ai:run"], author: "testuser" },
+      ]),
+      getIssue: vi.fn(),
+      getAuthenticatedUser: vi.fn(async () => "testuser"),
+      commentOnIssue: vi.fn(),
+      createPr: vi.fn(),
+      getCiStatus: vi.fn(),
+      mergePr: vi.fn(),
+      closeIssue: vi.fn(),
+      getCheckRunLogs: vi.fn(),
+    };
+    vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
+
+    const mockRunWorkflow = vi.mocked(runWorkflow);
+    mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+      ...ctx,
+      state: "manual_handoff",
+      _timedOutState: "implementing",
+      handoffReason: "State implementing timed out after 1800000ms",
+    }));
+
+    const originalSetInterval = global.setInterval;
+    vi.spyOn(global, "setInterval").mockImplementation(((
+      fn: Function,
+      ms: number
+    ) => {
+      return originalSetInterval(() => {}, ms);
+    }) as any);
+
+    const cli = createCli();
+    await cli.parseAsync([
+      "node",
+      "aidev",
+      "watch",
+      "--repo",
+      "owner/repo",
+      "--interval",
+      "999",
+    ]);
+
+    // Wait for fire-and-forget to settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockRunWorkflow).toHaveBeenCalledTimes(1);
+
+    // addWorktree called once (for creating the worktree)
+    expect(mockAddWorktree).toHaveBeenCalledTimes(1);
+
+    // removeWorktree should NOT be called — worktree preserved for manual_handoff
+    expect(mockRemoveWorktree).not.toHaveBeenCalled();
+  });
+
+  it("cleans up worktree when watch mode issue completes normally", async () => {
+    const mockGithub = {
+      listIssuesByLabel: vi.fn(async () => [
+        { number: 56, title: "Normal issue", body: "body", labels: ["ai:run"], author: "testuser" },
+      ]),
+      getIssue: vi.fn(),
+      getAuthenticatedUser: vi.fn(async () => "testuser"),
+      commentOnIssue: vi.fn(),
+      createPr: vi.fn(),
+      getCiStatus: vi.fn(),
+      mergePr: vi.fn(),
+      closeIssue: vi.fn(),
+      getCheckRunLogs: vi.fn(),
+    };
+    vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
+
+    const mockRunWorkflow = vi.mocked(runWorkflow);
+    mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+      ...ctx,
+      state: "done",
+    }));
+
+    const originalSetInterval = global.setInterval;
+    vi.spyOn(global, "setInterval").mockImplementation(((
+      fn: Function,
+      ms: number
+    ) => {
+      return originalSetInterval(() => {}, ms);
+    }) as any);
+
+    const cli = createCli();
+    await cli.parseAsync([
+      "node",
+      "aidev",
+      "watch",
+      "--repo",
+      "owner/repo",
+      "--interval",
+      "999",
+    ]);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockRunWorkflow).toHaveBeenCalledTimes(1);
+
+    // Normal completion → worktree should be cleaned up
+    expect(mockRemoveWorktree).toHaveBeenCalledTimes(1);
+  });
+
   it("creates unique runIds for each issue", async () => {
     const mockGithub = {
       listIssuesByLabel: vi.fn(async () => [

--- a/test/cli-watch.test.ts
+++ b/test/cli-watch.test.ts
@@ -356,8 +356,12 @@ describe("watch command", () => {
 
     expect(mockRunWorkflow).toHaveBeenCalledTimes(2);
 
-    const ctx1 = mockRunWorkflow.mock.calls[0][0];
-    const ctx2 = mockRunWorkflow.mock.calls[1][0];
+    // Sort by issue number since fire-and-forget ordering is non-deterministic
+    const calls = mockRunWorkflow.mock.calls
+      .map((c: any) => c[0])
+      .sort((a: any, b: any) => a.issueNumber - b.issueNumber);
+    const ctx1 = calls[0];
+    const ctx2 = calls[1];
 
     expect(ctx1.runId).not.toBe(ctx2.runId);
     expect(ctx1.issueNumber).toBe(10);

--- a/test/cli-watch.test.ts
+++ b/test/cli-watch.test.ts
@@ -1208,6 +1208,208 @@ describe("run command", () => {
     }
   });
 
+  it("reuses worktree when resuming from manual_handoff with _timedOutState", async () => {
+    const { mkdtemp, mkdir, writeFile, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const tempHome = await mkdtemp(join(tmpdir(), "aidev-resume-"));
+    const runDir = join(tempHome, ".aidev", "runs", "run-resume-test");
+    await mkdir(runDir, { recursive: true });
+    await writeFile(
+      join(runDir, "state.json"),
+      JSON.stringify({
+        runId: "run-resume-test",
+        targetKind: "issue",
+        issueNumber: 42,
+        repo: "owner/repo",
+        cwd: "/tmp/stale-worktree/.worktrees/issue-42",
+        state: "manual_handoff",
+        _timedOutState: "implementing",
+        handoffReason: "State implementing timed out after 1800000ms",
+        branch: "aidev/issue-42",
+        base: "main",
+        maxFixAttempts: 3,
+        fixAttempts: 0,
+        dryRun: false,
+        autoMerge: false,
+        issueLabels: [],
+        skipAuthorCheck: false,
+        skipStates: [],
+      })
+    );
+
+    const originalHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    // Worktree exists on disk (preserved from manual_handoff)
+    mockExistsSync.mockReturnValue(true);
+
+    try {
+      const mockRunWorkflow = vi.mocked(runWorkflow);
+      mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+        ...ctx,
+        state: "done",
+      }));
+
+      const cli = createCli();
+      await cli.parseAsync([
+        "node",
+        "aidev",
+        "run",
+        "--issue",
+        "42",
+        "--repo",
+        "owner/repo",
+        "--cwd",
+        "/tmp/real-repo",
+        "--resume",
+        "--yes",
+      ]);
+
+      // manual_handoff → _timedOutState "implementing" → non-terminal → reuse worktree
+      expect(mockAddWorktree).not.toHaveBeenCalled();
+
+      // ctx.state should be restored to the timed-out state
+      const ctx = mockRunWorkflow.mock.calls[0][0];
+      expect(ctx.state).toBe("implementing");
+    } finally {
+      mockExistsSync.mockReturnValue(false);
+      process.env.HOME = originalHome;
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to init when resuming from manual_handoff without _timedOutState", async () => {
+    const { mkdtemp, mkdir, writeFile, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const tempHome = await mkdtemp(join(tmpdir(), "aidev-resume-"));
+    const runDir = join(tempHome, ".aidev", "runs", "run-resume-test");
+    await mkdir(runDir, { recursive: true });
+    await writeFile(
+      join(runDir, "state.json"),
+      JSON.stringify({
+        runId: "run-resume-test",
+        targetKind: "issue",
+        issueNumber: 42,
+        repo: "owner/repo",
+        cwd: "/tmp/stale-worktree/.worktrees/issue-42",
+        state: "manual_handoff",
+        handoffReason: "Manual handoff without timed out state",
+        branch: "aidev/issue-42",
+        base: "main",
+        maxFixAttempts: 3,
+        fixAttempts: 0,
+        dryRun: false,
+        autoMerge: false,
+        issueLabels: [],
+        skipAuthorCheck: false,
+        skipStates: [],
+      })
+    );
+
+    const originalHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    // Worktree exists on disk (preserved from manual_handoff)
+    mockExistsSync.mockReturnValue(true);
+
+    try {
+      const mockRunWorkflow = vi.mocked(runWorkflow);
+      mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+        ...ctx,
+        state: "done",
+      }));
+
+      const cli = createCli();
+      await cli.parseAsync([
+        "node",
+        "aidev",
+        "run",
+        "--issue",
+        "42",
+        "--repo",
+        "owner/repo",
+        "--cwd",
+        "/tmp/real-repo",
+        "--resume",
+        "--yes",
+      ]);
+
+      // No _timedOutState → falls back to "init" (non-terminal) → reuse worktree
+      expect(mockAddWorktree).not.toHaveBeenCalled();
+
+      const ctx = mockRunWorkflow.mock.calls[0][0];
+      expect(ctx.state).toBe("init");
+    } finally {
+      mockExistsSync.mockReturnValue(false);
+      process.env.HOME = originalHome;
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves worktree when workflow result is manual_handoff", async () => {
+    const { mkdtemp, mkdir, writeFile, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const tempHome = await mkdtemp(join(tmpdir(), "aidev-resume-wt-"));
+    const originalHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    const mockGithub = {
+      listIssuesByLabel: vi.fn(async () => []),
+      getIssue: vi.fn(async () => ({
+        number: 42,
+        title: "Test issue",
+        body: "body",
+        labels: [],
+        author: "testuser",
+      })),
+      getAuthenticatedUser: vi.fn(async () => "testuser"),
+      commentOnIssue: vi.fn(),
+      createPr: vi.fn(),
+      getCiStatus: vi.fn(),
+      mergePr: vi.fn(),
+      closeIssue: vi.fn(),
+      getCheckRunLogs: vi.fn(),
+    };
+    vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
+
+    try {
+      const mockRunWorkflow = vi.mocked(runWorkflow);
+      mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+        ...ctx,
+        state: "manual_handoff",
+        _timedOutState: "implementing",
+        handoffReason: "State implementing timed out after 1800000ms",
+      }));
+
+      const cli = createCli();
+      await cli.parseAsync([
+        "node",
+        "aidev",
+        "run",
+        "--issue",
+        "42",
+        "--repo",
+        "owner/repo",
+        "--yes",
+      ]);
+
+      // Worktree created for new run
+      expect(mockAddWorktree).toHaveBeenCalled();
+
+      // manual_handoff → keepWorktree = true → removeWorktree NOT called in finally
+      expect(mockRemoveWorktree).toHaveBeenCalledTimes(1); // only stale cleanup before addWorktree
+    } finally {
+      process.env.HOME = originalHome;
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
   it("uses --base for worktree creation", async () => {
     const mockGithub = {
       listIssuesByLabel: vi.fn(async () => []),

--- a/test/cli-watch.test.ts
+++ b/test/cli-watch.test.ts
@@ -65,6 +65,21 @@ import { createGitHubAdapter } from "../src/adapters/github.js";
 import { createStateHandlers } from "../src/workflow/states.js";
 import { runWorkflow } from "../src/workflow/engine.js";
 
+function makeMockGithub(overrides: Record<string, any> = {}) {
+  return {
+    listIssuesByLabel: vi.fn(async () => []),
+    getIssue: vi.fn(),
+    getAuthenticatedUser: vi.fn(async () => "testuser"),
+    commentOnIssue: vi.fn(),
+    createPr: vi.fn(),
+    getCiStatus: vi.fn(),
+    mergePr: vi.fn(),
+    closeIssue: vi.fn(),
+    getCheckRunLogs: vi.fn(),
+    ...overrides,
+  };
+}
+
 describe("watch command", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -208,19 +223,11 @@ describe("watch command", () => {
   });
 
   it("preserves worktree when watch mode issue ends in manual_handoff", async () => {
-    const mockGithub = {
+    const mockGithub = makeMockGithub({
       listIssuesByLabel: vi.fn(async () => [
         { number: 55, title: "Timeout issue", body: "body", labels: ["ai:run"], author: "testuser" },
       ]),
-      getIssue: vi.fn(),
-      getAuthenticatedUser: vi.fn(async () => "testuser"),
-      commentOnIssue: vi.fn(),
-      createPr: vi.fn(),
-      getCiStatus: vi.fn(),
-      mergePr: vi.fn(),
-      closeIssue: vi.fn(),
-      getCheckRunLogs: vi.fn(),
-    };
+    });
     vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
 
     const mockRunWorkflow = vi.mocked(runWorkflow);
@@ -263,19 +270,11 @@ describe("watch command", () => {
   });
 
   it("cleans up worktree when watch mode issue completes normally", async () => {
-    const mockGithub = {
+    const mockGithub = makeMockGithub({
       listIssuesByLabel: vi.fn(async () => [
         { number: 56, title: "Normal issue", body: "body", labels: ["ai:run"], author: "testuser" },
       ]),
-      getIssue: vi.fn(),
-      getAuthenticatedUser: vi.fn(async () => "testuser"),
-      commentOnIssue: vi.fn(),
-      createPr: vi.fn(),
-      getCiStatus: vi.fn(),
-      mergePr: vi.fn(),
-      closeIssue: vi.fn(),
-      getCheckRunLogs: vi.fn(),
-    };
+    });
     vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
 
     const mockRunWorkflow = vi.mocked(runWorkflow);
@@ -1113,7 +1112,7 @@ describe("run command", () => {
     }
   });
 
-  it("errors when resuming non-terminal state but worktree does not exist", async () => {
+  it("recreates worktree from init when resuming non-terminal state but worktree does not exist", async () => {
     const { mkdtemp, mkdir, writeFile, rm } = await import("node:fs/promises");
     const { tmpdir } = await import("node:os");
     const { join } = await import("node:path");
@@ -1149,6 +1148,12 @@ describe("run command", () => {
     mockExistsSync.mockReturnValue(false);
 
     try {
+      const mockRunWorkflow = vi.mocked(runWorkflow);
+      mockRunWorkflow.mockImplementation(async (ctx: any) => ({
+        ...ctx,
+        state: "done",
+      }));
+
       const cli = createCli();
       await cli.parseAsync([
         "node",
@@ -1164,8 +1169,10 @@ describe("run command", () => {
         "--yes",
       ]);
 
-      // Should exit with error
-      expect(process.exit).toHaveBeenCalledWith(1);
+      // Worktree missing → recreated from scratch, state reset to init
+      expect(mockAddWorktree).toHaveBeenCalled();
+      const ctx = mockRunWorkflow.mock.calls[0][0];
+      expect(ctx.state).toBe("init");
     } finally {
       mockExistsSync.mockReturnValue(false);
       process.env.HOME = originalHome;
@@ -1463,8 +1470,7 @@ describe("run command", () => {
     const originalHome = process.env.HOME;
     process.env.HOME = tempHome;
 
-    const mockGithub = {
-      listIssuesByLabel: vi.fn(async () => []),
+    vi.mocked(createGitHubAdapter).mockReturnValue(makeMockGithub({
       getIssue: vi.fn(async () => ({
         number: 42,
         title: "Test issue",
@@ -1472,15 +1478,7 @@ describe("run command", () => {
         labels: [],
         author: "testuser",
       })),
-      getAuthenticatedUser: vi.fn(async () => "testuser"),
-      commentOnIssue: vi.fn(),
-      createPr: vi.fn(),
-      getCiStatus: vi.fn(),
-      mergePr: vi.fn(),
-      closeIssue: vi.fn(),
-      getCheckRunLogs: vi.fn(),
-    };
-    vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
+    }));
 
     try {
       const mockRunWorkflow = vi.mocked(runWorkflow);
@@ -1515,8 +1513,7 @@ describe("run command", () => {
   });
 
   it("uses --base for worktree creation", async () => {
-    const mockGithub = {
-      listIssuesByLabel: vi.fn(async () => []),
+    vi.mocked(createGitHubAdapter).mockReturnValue(makeMockGithub({
       getIssue: vi.fn(async () => ({
         number: 42,
         title: "Test issue",
@@ -1524,15 +1521,7 @@ describe("run command", () => {
         labels: [],
         author: "testuser",
       })),
-      getAuthenticatedUser: vi.fn(async () => "testuser"),
-      commentOnIssue: vi.fn(),
-      createPr: vi.fn(),
-      getCiStatus: vi.fn(),
-      mergePr: vi.fn(),
-      closeIssue: vi.fn(),
-      getCheckRunLogs: vi.fn(),
-    };
-    vi.mocked(createGitHubAdapter).mockReturnValue(mockGithub);
+    }));
 
     const mockRunWorkflow = vi.mocked(runWorkflow);
     mockRunWorkflow.mockImplementation(async (ctx: any) => ({

--- a/test/config/issue-config.test.ts
+++ b/test/config/issue-config.test.ts
@@ -176,4 +176,44 @@ describe("parseIssueConfig", () => {
     expect(result.language).toBeUndefined();
     expect(result.maxFixAttempts).toBe(3);
   });
+
+  it("parses stateTimeouts with valid state keys", () => {
+    const body = [
+      "```aidev",
+      "stateTimeouts:",
+      "  implementing: 1800000",
+      "  reviewing: 600000",
+      "```",
+    ].join("\n");
+    const result = parseIssueConfig(body);
+    expect(result.stateTimeouts).toEqual({
+      implementing: 1800000,
+      reviewing: 600000,
+    });
+  });
+
+  it("ignores stateTimeouts with invalid state keys", () => {
+    const body = [
+      "```aidev",
+      "stateTimeouts:",
+      "  implementing: 1800000",
+      "  nonexistent: 600000",
+      "```",
+    ].join("\n");
+    const result = parseIssueConfig(body);
+    expect(result.stateTimeouts).toEqual({
+      implementing: 1800000,
+    });
+  });
+
+  it("ignores stateTimeouts with non-numeric values", () => {
+    const body = [
+      "```aidev",
+      "stateTimeouts:",
+      "  implementing: abc",
+      "```",
+    ].join("\n");
+    const result = parseIssueConfig(body);
+    expect(result.stateTimeouts).toBeUndefined();
+  });
 });

--- a/test/config/issue-config.test.ts
+++ b/test/config/issue-config.test.ts
@@ -256,4 +256,57 @@ describe("parseIssueConfig", () => {
       implementing: 5000,
     });
   });
+
+  it("rejects stateTimeouts above MAX_STATE_TIMEOUT_MS (1 hour)", () => {
+    const body = [
+      "```aidev",
+      "stateTimeouts:",
+      "  implementing: 7200000",
+      "  reviewing: 600000",
+      "```",
+    ].join("\n");
+    const result = parseIssueConfig(body);
+    // implementing: 7200000 (2h) exceeds 3600000 (1h) max → rejected
+    // reviewing: 600000 (10min) is within range → accepted
+    expect(result.stateTimeouts).toEqual({
+      reviewing: 600000,
+    });
+  });
+
+  it("accepts stateTimeouts of exactly MAX_STATE_TIMEOUT_MS", () => {
+    const body = [
+      "```aidev",
+      "stateTimeouts:",
+      "  implementing: 3600000",
+      "```",
+    ].join("\n");
+    const result = parseIssueConfig(body);
+    expect(result.stateTimeouts).toEqual({
+      implementing: 3600000,
+    });
+  });
+
+  it("rejects base field with path traversal", () => {
+    const body = "```aidev\nbase: ../../etc/passwd\n```";
+    const result = parseIssueConfig(body);
+    expect(result.base).toBeUndefined();
+  });
+
+  it("rejects base field with special characters", () => {
+    const body = "```aidev\nbase: main; rm -rf /\n```";
+    const result = parseIssueConfig(body);
+    expect(result.base).toBeUndefined();
+  });
+
+  it("accepts valid branch names in base field", () => {
+    const body = "```aidev\nbase: release/1.3\n```";
+    const result = parseIssueConfig(body);
+    expect(result.base).toBe("release/1.3");
+  });
+
+  it("accepts tag-style base values", () => {
+    const body = "```aidev\nbase: v1.2.0\n```";
+    const result = parseIssueConfig(body);
+    expect(result.base).toBe("v1.2.0");
+  });
 });

--- a/test/config/issue-config.test.ts
+++ b/test/config/issue-config.test.ts
@@ -216,4 +216,44 @@ describe("parseIssueConfig", () => {
     const result = parseIssueConfig(body);
     expect(result.stateTimeouts).toBeUndefined();
   });
+
+  it("rejects stateTimeouts below MIN_STATE_TIMEOUT_MS (5000ms)", () => {
+    const body = [
+      "```aidev",
+      "stateTimeouts:",
+      "  implementing: 1",
+      "  reviewing: 10000",
+      "```",
+    ].join("\n");
+    const result = parseIssueConfig(body);
+    // implementing: 1ms is below 5000ms minimum → rejected
+    // reviewing: 10000ms is above minimum → accepted
+    expect(result.stateTimeouts).toEqual({
+      reviewing: 10000,
+    });
+  });
+
+  it("rejects stateTimeouts of exactly MIN_STATE_TIMEOUT_MS - 1", () => {
+    const body = [
+      "```aidev",
+      "stateTimeouts:",
+      "  implementing: 4999",
+      "```",
+    ].join("\n");
+    const result = parseIssueConfig(body);
+    expect(result.stateTimeouts).toBeUndefined();
+  });
+
+  it("accepts stateTimeouts of exactly MIN_STATE_TIMEOUT_MS", () => {
+    const body = [
+      "```aidev",
+      "stateTimeouts:",
+      "  implementing: 5000",
+      "```",
+    ].join("\n");
+    const result = parseIssueConfig(body);
+    expect(result.stateTimeouts).toEqual({
+      implementing: 5000,
+    });
+  });
 });

--- a/test/config/merge-config.test.ts
+++ b/test/config/merge-config.test.ts
@@ -79,4 +79,39 @@ describe("mergeConfigs", () => {
     expect(result).not.toHaveProperty("backend");
     expect(result).not.toHaveProperty("model");
   });
+
+  it("deep-merges stateTimeouts from repo and issue", () => {
+    const repo: Partial<IssueConfig> = {
+      stateTimeouts: { implementing: 1800000, reviewing: 600000 },
+    };
+    const issue: Partial<IssueConfig> = {
+      stateTimeouts: { implementing: 3600000 },
+    };
+
+    const result = mergeConfigs(repo, issue, new Set());
+
+    expect(result.stateTimeouts).toEqual({
+      implementing: 3600000,
+      reviewing: 600000,
+    });
+  });
+
+  it("uses repo stateTimeouts when issue has none", () => {
+    const repo: Partial<IssueConfig> = {
+      stateTimeouts: { implementing: 1800000 },
+    };
+
+    const result = mergeConfigs(repo, {}, new Set());
+
+    expect(result.stateTimeouts).toEqual({ implementing: 1800000 });
+  });
+
+  it("excludes stateTimeouts when cli-explicit", () => {
+    const repo: Partial<IssueConfig> = {
+      stateTimeouts: { implementing: 1800000 },
+    };
+    const result = mergeConfigs(repo, {}, new Set(["stateTimeouts"]));
+
+    expect(result).not.toHaveProperty("stateTimeouts");
+  });
 });

--- a/test/config/serialize-config.test.ts
+++ b/test/config/serialize-config.test.ts
@@ -68,6 +68,39 @@ describe("serializeConfig", () => {
     expect(result).not.toContain("model");
   });
 
+  it("serializes stateTimeouts as nested map", () => {
+    const config: ResolvedConfig = {
+      maxFixAttempts: 3,
+      maxReviewRounds: 1,
+      autoMerge: false,
+      dryRun: false,
+      base: "main",
+      language: "ja",
+      skip: [],
+      stateTimeouts: { implementing: 1800000, reviewing: 600000 },
+    };
+
+    const result = serializeConfig(config);
+    expect(result).toContain("stateTimeouts:");
+    expect(result).toContain("  implementing: 1800000");
+    expect(result).toContain("  reviewing: 600000");
+  });
+
+  it("omits stateTimeouts when empty or undefined", () => {
+    const config: ResolvedConfig = {
+      maxFixAttempts: 3,
+      maxReviewRounds: 1,
+      autoMerge: false,
+      dryRun: false,
+      base: "main",
+      language: "ja",
+      skip: [],
+    };
+
+    const result = serializeConfig(config);
+    expect(result).not.toContain("stateTimeouts");
+  });
+
   it("omits skip line when skip is empty array", () => {
     const config: ResolvedConfig = {
       maxFixAttempts: 3,

--- a/test/config/serialize-config.test.ts
+++ b/test/config/serialize-config.test.ts
@@ -86,6 +86,25 @@ describe("serializeConfig", () => {
     expect(result).toContain("  reviewing: 600000");
   });
 
+  it("sorts stateTimeouts entries alphabetically", () => {
+    const config: ResolvedConfig = {
+      maxFixAttempts: 3,
+      maxReviewRounds: 1,
+      autoMerge: false,
+      dryRun: false,
+      base: "main",
+      language: "ja",
+      skip: [],
+      stateTimeouts: { reviewing: 600000, implementing: 1800000 },
+    };
+
+    const result = serializeConfig(config);
+    const lines = result.split("\n");
+    const timeoutLines = lines.filter((l) => l.startsWith("  ") && l.includes(":"));
+    expect(timeoutLines[0]).toContain("implementing");
+    expect(timeoutLines[1]).toContain("reviewing");
+  });
+
   it("omits stateTimeouts when empty or undefined", () => {
     const config: ResolvedConfig = {
       maxFixAttempts: 3,
@@ -152,6 +171,30 @@ describe("buildResolvedConfigBlock", () => {
         "```",
       ].join("\n"),
     );
+  });
+});
+
+describe("stateTimeouts round-trip", () => {
+  it("serialize → parse preserves stateTimeouts values", async () => {
+    const { parseConfigBlock } = await import("../../src/config/issue-config.js");
+    const config: ResolvedConfig = {
+      maxFixAttempts: 3,
+      maxReviewRounds: 1,
+      autoMerge: false,
+      dryRun: false,
+      base: "main",
+      language: "ja",
+      skip: [],
+      stateTimeouts: { implementing: 1800000, reviewing: 600000 },
+    };
+
+    const serialized = serializeConfig(config);
+    const parsed = parseConfigBlock(serialized);
+
+    expect(parsed.stateTimeouts).toEqual({
+      implementing: 1800000,
+      reviewing: 600000,
+    });
   });
 });
 

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -30,6 +30,7 @@ describe("RunStateSchema", () => {
       "done",
       "failed",
       "blocked",
+      "manual_handoff",
     ];
     for (const state of validStates) {
       expect(RunStateSchema.parse(state)).toBe(state);
@@ -325,5 +326,62 @@ describe("RunContextSchema", () => {
   it("accepts language en", () => {
     const parsed = RunContextSchema.parse({ ...validContext, language: "en" });
     expect(parsed.language).toBe("en");
+  });
+
+  it("accepts handoffReason", () => {
+    const parsed = RunContextSchema.parse({
+      ...validContext,
+      state: "manual_handoff",
+      handoffReason: "implementing timed out after 30m",
+    });
+    expect(parsed.handoffReason).toBe("implementing timed out after 30m");
+  });
+
+  it("defaults handoffReason to undefined", () => {
+    const parsed = RunContextSchema.parse(validContext);
+    expect(parsed.handoffReason).toBeUndefined();
+  });
+
+  it("accepts _timedOutState as valid RunState", () => {
+    const parsed = RunContextSchema.parse({
+      ...validContext,
+      state: "manual_handoff",
+      _timedOutState: "implementing",
+    });
+    expect(parsed._timedOutState).toBe("implementing");
+  });
+
+  it("rejects _timedOutState with invalid state", () => {
+    expect(() =>
+      RunContextSchema.parse({
+        ...validContext,
+        _timedOutState: "nonexistent_state",
+      })
+    ).toThrow();
+  });
+
+  it("accepts stateTimeouts with valid state keys", () => {
+    const parsed = RunContextSchema.parse({
+      ...validContext,
+      stateTimeouts: { implementing: 1800000, reviewing: 600000 },
+    });
+    expect(parsed.stateTimeouts).toEqual({
+      implementing: 1800000,
+      reviewing: 600000,
+    });
+  });
+
+  it("rejects stateTimeouts with invalid state keys", () => {
+    expect(() =>
+      RunContextSchema.parse({
+        ...validContext,
+        stateTimeouts: { nonexistent: 1000 },
+      })
+    ).toThrow();
+  });
+
+  it("defaults stateTimeouts to undefined", () => {
+    const parsed = RunContextSchema.parse(validContext);
+    expect(parsed.stateTimeouts).toBeUndefined();
   });
 });

--- a/test/workflow/engine.test.ts
+++ b/test/workflow/engine.test.ts
@@ -572,3 +572,102 @@ describe("runWorkflow with stateTimeouts", () => {
     expect(result.state).toBe("done");
   });
 });
+
+describe("E2E: timeout → manual_handoff → resume → done", () => {
+  it("full lifecycle with real timeout firing", async () => {
+    let implementingCallCount = 0;
+
+    // First call: slow handler that will be timed out (takes 200ms, timeout is 30ms)
+    // Second call (resume): fast handler that completes immediately
+    const implementingHandler: StateHandler = async (ctx) => {
+      implementingCallCount++;
+      if (implementingCallCount === 1) {
+        // Simulate slow work that will be interrupted by timeout
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        return { nextState: "reviewing" as RunState, ctx };
+      }
+      // Resume: complete immediately
+      return { nextState: "reviewing" as RunState, ctx };
+    };
+
+    const handlers: StateHandlerMap = {
+      init: makeHandler("implementing"),
+      implementing: implementingHandler,
+      reviewing: makeHandler("done"),
+    };
+
+    const savedContexts: RunContext[] = [];
+    const persistence: Persistence = {
+      save: vi.fn(async (ctx) => { savedContexts.push({ ...ctx }); }),
+      load: vi.fn(async () => null),
+    };
+
+    // Phase 1: Run with stateTimeouts — should timeout and reach manual_handoff
+    const phase1Ctx = makeCtx({
+      state: "init",
+      stateTimeouts: { implementing: 30 },
+    });
+
+    const phase1Result = await runWorkflow(phase1Ctx, handlers, persistence);
+
+    expect(phase1Result.state).toBe("manual_handoff");
+    expect(phase1Result._timedOutState).toBe("implementing");
+    expect(phase1Result.handoffReason).toContain("timed out");
+
+    // Verify persistence saved the manual_handoff state
+    const handoffSave = savedContexts.find((c) => c.state === "manual_handoff");
+    expect(handoffSave).toBeDefined();
+    expect(handoffSave!._timedOutState).toBe("implementing");
+
+    // Phase 2: Resume from manual_handoff (simulate what CLI does)
+    const phase2Ctx = makeCtx({
+      ...phase1Result,
+      state: phase1Result._timedOutState as RunState, // CLI restores timed-out state
+      stateTimeouts: undefined, // Clear timeouts for resume (or use longer ones)
+    });
+
+    const phase2Result = await runWorkflow(phase2Ctx, handlers, persistence);
+
+    expect(phase2Result.state).toBe("done");
+    expect(implementingCallCount).toBe(2); // Called twice: once timed out, once completed
+
+    // Verify the full state progression was saved
+    const savedStates = savedContexts.map((c) => c.state);
+    expect(savedStates).toContain("implementing"); // Phase 1: init → implementing
+    expect(savedStates).toContain("manual_handoff"); // Phase 1: timeout
+    expect(savedStates).toContain("reviewing"); // Phase 2: implementing → reviewing
+    expect(savedStates).toContain("done"); // Phase 2: reviewing → done
+  });
+
+  it("preserves handoffReason and _timedOutState through persistence", async () => {
+    const handlers: StateHandlerMap = {
+      reviewing: async (ctx) => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        return { nextState: "committing" as RunState, ctx };
+      },
+    };
+
+    let lastSaved: RunContext | null = null;
+    const persistence: Persistence = {
+      save: vi.fn(async (ctx) => { lastSaved = { ...ctx }; }),
+      load: vi.fn(async () => lastSaved),
+    };
+
+    const ctx = makeCtx({
+      state: "reviewing",
+      stateTimeouts: { reviewing: 30 },
+    });
+
+    const result = await runWorkflow(ctx, handlers, persistence);
+
+    expect(result.state).toBe("manual_handoff");
+
+    // Simulate loading from persistence (as CLI --resume would)
+    const loaded = await persistence.load("test-run");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.state).toBe("manual_handoff");
+    expect(loaded!._timedOutState).toBe("reviewing");
+    expect(loaded!.handoffReason).toContain("reviewing");
+    expect(loaded!.handoffReason).toContain("timed out");
+  });
+});

--- a/test/workflow/engine.test.ts
+++ b/test/workflow/engine.test.ts
@@ -455,6 +455,32 @@ describe("withTimeout", () => {
     expect(logger.warn).toHaveBeenCalled();
   });
 
+  it("returns handler result when timeoutMs is zero (no-op)", async () => {
+    const inner: StateHandler = async (ctx) => ({
+      nextState: "reviewing" as RunState,
+      ctx,
+    });
+
+    const wrapped = withTimeout(inner, 0);
+    const ctx = makeCtx({ state: "implementing" });
+    const result = await wrapped(ctx);
+
+    expect(result.nextState).toBe("reviewing");
+  });
+
+  it("returns handler result when timeoutMs is negative (no-op)", async () => {
+    const inner: StateHandler = async (ctx) => ({
+      nextState: "reviewing" as RunState,
+      ctx,
+    });
+
+    const wrapped = withTimeout(inner, -1000);
+    const ctx = makeCtx({ state: "implementing" });
+    const result = await wrapped(ctx);
+
+    expect(result.nextState).toBe("reviewing");
+  });
+
   it("returns handler result when timeoutMs is Infinity", async () => {
     const inner: StateHandler = async (ctx) => ({
       nextState: "reviewing" as RunState,

--- a/test/workflow/engine.test.ts
+++ b/test/workflow/engine.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   runWorkflow,
+  withTimeout,
   type StateHandlerMap,
   type Persistence,
 } from "../../src/workflow/engine.js";
-import type { RunContext, RunState } from "../../src/types.js";
+import type { RunContext, RunState, StateHandler } from "../../src/types.js";
 import type { Logger } from "../../src/util/logger.js";
 
 function makeCtx(overrides: Partial<RunContext> = {}): RunContext {
@@ -385,5 +386,98 @@ describe("runWorkflow", () => {
       { from: "init", to: "planning" },
       { from: "planning", to: "done" },
     ]);
+  });
+
+  it("stops at terminal state manual_handoff", async () => {
+    const handlers: StateHandlerMap = {
+      implementing: vi.fn(async (ctx) => ({
+        nextState: "manual_handoff" as RunState,
+        ctx: { ...ctx, handoffReason: "test timeout" },
+      })),
+    };
+    const persistence = makePersistence();
+    const ctx = makeCtx({ state: "implementing" });
+
+    const result = await runWorkflow(ctx, handlers, persistence);
+
+    expect(result.state).toBe("manual_handoff");
+    expect(result.handoffReason).toBe("test timeout");
+  });
+
+  it("calls onComplete for manual_handoff terminal state", async () => {
+    const handlers: StateHandlerMap = {
+      init: vi.fn(async (ctx) => ({
+        nextState: "manual_handoff" as RunState,
+        ctx,
+      })),
+    };
+    const persistence = makePersistence();
+    const ctx = makeCtx();
+    const onComplete = vi.fn(async () => {});
+
+    await runWorkflow(ctx, handlers, persistence, { onComplete });
+
+    expect(onComplete).toHaveBeenCalledOnce();
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ state: "manual_handoff" })
+    );
+  });
+});
+
+describe("withTimeout", () => {
+  it("returns handler result when handler completes before timeout", async () => {
+    const inner: StateHandler = async (ctx) => ({
+      nextState: "reviewing" as RunState,
+      ctx,
+    });
+
+    const wrapped = withTimeout(inner, 5000);
+    const ctx = makeCtx({ state: "implementing" });
+    const result = await wrapped(ctx);
+
+    expect(result.nextState).toBe("reviewing");
+  });
+
+  it("returns manual_handoff when handler exceeds timeout", async () => {
+    const inner: StateHandler = async (ctx) => {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      return { nextState: "reviewing" as RunState, ctx };
+    };
+
+    const logger: Logger = { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const wrapped = withTimeout(inner, 50, logger);
+    const ctx = makeCtx({ state: "implementing" });
+    const result = await wrapped(ctx);
+
+    expect(result.nextState).toBe("manual_handoff");
+    expect(result.ctx._timedOutState).toBe("implementing");
+    expect(result.ctx.handoffReason).toContain("implementing");
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("returns handler result when timeoutMs is Infinity", async () => {
+    const inner: StateHandler = async (ctx) => ({
+      nextState: "reviewing" as RunState,
+      ctx,
+    });
+
+    const wrapped = withTimeout(inner, Infinity);
+    const ctx = makeCtx({ state: "implementing" });
+    const result = await wrapped(ctx);
+
+    expect(result.nextState).toBe("reviewing");
+  });
+
+  it("preserves context fields through timeout wrapper", async () => {
+    const inner: StateHandler = async (ctx) => ({
+      nextState: "committing" as RunState,
+      ctx: { ...ctx, fixAttempts: 2 },
+    });
+
+    const wrapped = withTimeout(inner, 5000);
+    const ctx = makeCtx({ state: "implementing" });
+    const result = await wrapped(ctx);
+
+    expect(result.ctx.fixAttempts).toBe(2);
   });
 });

--- a/test/workflow/engine.test.ts
+++ b/test/workflow/engine.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   runWorkflow,
   withTimeout,
+  MIN_STATE_TIMEOUT_MS,
   type StateHandlerMap,
   type Persistence,
 } from "../../src/workflow/engine.js";
@@ -569,14 +570,33 @@ describe("withTimeout", () => {
 });
 
 describe("runWorkflow with stateTimeouts", () => {
-  it("applies timeout to handler when stateTimeouts is configured", async () => {
-    // Handler that takes 200ms but has a 50ms timeout
+  it("applies timeout to handler when stateTimeouts >= MIN_STATE_TIMEOUT_MS", async () => {
     const slowHandler: StateHandler = async (ctx) => {
       await new Promise((resolve) => setTimeout(resolve, 200));
-      return { nextState: "reviewing" as RunState, ctx };
+      return { nextState: "done" as RunState, ctx };
     };
     const handlers: StateHandlerMap = {
       implementing: slowHandler,
+    };
+    const persistence = makePersistence();
+    const ctx = makeCtx({
+      state: "implementing",
+      stateTimeouts: { implementing: MIN_STATE_TIMEOUT_MS },
+    });
+
+    // Handler completes in 200ms which is before MIN_STATE_TIMEOUT_MS (5000ms),
+    // so timeout should NOT fire — handler completes normally
+    const result = await runWorkflow(ctx, handlers, persistence);
+    expect(result.state).toBe("done");
+  });
+
+  it("ignores stateTimeouts below MIN_STATE_TIMEOUT_MS", async () => {
+    const handlers: StateHandlerMap = {
+      implementing: async (ctx) => {
+        // This would time out if 50ms were applied, but MIN enforcement skips it
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return { nextState: "done" as RunState, ctx };
+      },
     };
     const persistence = makePersistence();
     const ctx = makeCtx({
@@ -585,9 +605,8 @@ describe("runWorkflow with stateTimeouts", () => {
     });
 
     const result = await runWorkflow(ctx, handlers, persistence);
-
-    expect(result.state).toBe("manual_handoff");
-    expect(result._timedOutState).toBe("implementing");
+    // 50ms < MIN_STATE_TIMEOUT_MS → timeout not applied → handler completes
+    expect(result.state).toBe("done");
   });
 
   it("does not apply timeout when stateTimeouts is not set for the state", async () => {
@@ -596,7 +615,7 @@ describe("runWorkflow with stateTimeouts", () => {
     };
     const persistence = makePersistence();
     const ctx = makeCtx({
-      stateTimeouts: { implementing: 50 },
+      stateTimeouts: { implementing: MIN_STATE_TIMEOUT_MS },
     });
 
     const result = await runWorkflow(ctx, handlers, persistence);
@@ -609,22 +628,21 @@ describe("E2E: timeout → manual_handoff → resume → done", () => {
   it("full lifecycle with real timeout firing", async () => {
     let implementingCallCount = 0;
 
-    // First call: slow handler that will be timed out (takes 200ms, timeout is 30ms)
+    // First call: slow handler wrapped with withTimeout (30ms timeout, 200ms work)
     // Second call (resume): fast handler that completes immediately
-    const implementingHandler: StateHandler = async (ctx) => {
+    const rawImplementingHandler: StateHandler = async (ctx) => {
       implementingCallCount++;
       if (implementingCallCount === 1) {
-        // Simulate slow work that will be interrupted by timeout
         await new Promise((resolve) => setTimeout(resolve, 200));
         return { nextState: "reviewing" as RunState, ctx };
       }
-      // Resume: complete immediately
       return { nextState: "reviewing" as RunState, ctx };
     };
 
     const handlers: StateHandlerMap = {
       init: makeHandler("implementing"),
-      implementing: implementingHandler,
+      // Use withTimeout directly (bypasses MIN_STATE_TIMEOUT_MS in runWorkflow)
+      implementing: withTimeout(rawImplementingHandler, 30),
       reviewing: makeHandler("done"),
     };
 
@@ -634,11 +652,8 @@ describe("E2E: timeout → manual_handoff → resume → done", () => {
       load: vi.fn(async () => null),
     };
 
-    // Phase 1: Run with stateTimeouts — should timeout and reach manual_handoff
-    const phase1Ctx = makeCtx({
-      state: "init",
-      stateTimeouts: { implementing: 30 },
-    });
+    // Phase 1: Run — implementing handler has withTimeout(30ms)
+    const phase1Ctx = makeCtx({ state: "init" });
 
     const phase1Result = await runWorkflow(phase1Ctx, handlers, persistence);
 
@@ -651,32 +666,36 @@ describe("E2E: timeout → manual_handoff → resume → done", () => {
     expect(handoffSave).toBeDefined();
     expect(handoffSave!._timedOutState).toBe("implementing");
 
-    // Phase 2: Resume from manual_handoff (simulate what CLI does)
+    // Phase 2: Resume from manual_handoff — use raw handler (no timeout)
+    const resumeHandlers: StateHandlerMap = {
+      ...handlers,
+      implementing: rawImplementingHandler,
+    };
+
     const phase2Ctx = makeCtx({
       ...phase1Result,
-      state: phase1Result._timedOutState as RunState, // CLI restores timed-out state
-      stateTimeouts: undefined, // Clear timeouts for resume (or use longer ones)
+      state: phase1Result._timedOutState as RunState,
     });
 
-    const phase2Result = await runWorkflow(phase2Ctx, handlers, persistence);
+    const phase2Result = await runWorkflow(phase2Ctx, resumeHandlers, persistence);
 
     expect(phase2Result.state).toBe("done");
-    expect(implementingCallCount).toBe(2); // Called twice: once timed out, once completed
+    expect(implementingCallCount).toBe(2);
 
-    // Verify the full state progression was saved
     const savedStates = savedContexts.map((c) => c.state);
-    expect(savedStates).toContain("implementing"); // Phase 1: init → implementing
-    expect(savedStates).toContain("manual_handoff"); // Phase 1: timeout
-    expect(savedStates).toContain("reviewing"); // Phase 2: implementing → reviewing
-    expect(savedStates).toContain("done"); // Phase 2: reviewing → done
+    expect(savedStates).toContain("implementing");
+    expect(savedStates).toContain("manual_handoff");
+    expect(savedStates).toContain("reviewing");
+    expect(savedStates).toContain("done");
   });
 
   it("preserves handoffReason and _timedOutState through persistence", async () => {
+    // Use withTimeout directly to bypass MIN_STATE_TIMEOUT_MS
     const handlers: StateHandlerMap = {
-      reviewing: async (ctx) => {
+      reviewing: withTimeout(async (ctx) => {
         await new Promise((resolve) => setTimeout(resolve, 200));
         return { nextState: "committing" as RunState, ctx };
-      },
+      }, 30),
     };
 
     let lastSaved: RunContext | null = null;
@@ -685,10 +704,8 @@ describe("E2E: timeout → manual_handoff → resume → done", () => {
       load: vi.fn(async () => lastSaved),
     };
 
-    const ctx = makeCtx({
-      state: "reviewing",
-      stateTimeouts: { reviewing: 30 },
-    });
+    // No stateTimeouts needed — handler already wrapped with withTimeout
+    const ctx = makeCtx({ state: "reviewing" });
 
     const result = await runWorkflow(ctx, handlers, persistence);
 

--- a/test/workflow/engine.test.ts
+++ b/test/workflow/engine.test.ts
@@ -534,6 +534,38 @@ describe("withTimeout", () => {
     expect(clearSpy).toHaveBeenCalled();
     clearSpy.mockRestore();
   });
+
+  it("injects _abortSignal into handler ctx", async () => {
+    let receivedSignal: AbortSignal | undefined;
+    const inner: StateHandler = async (ctx) => {
+      receivedSignal = ctx._abortSignal;
+      return { nextState: "reviewing" as RunState, ctx };
+    };
+
+    const wrapped = withTimeout(inner, 60000);
+    const ctx = makeCtx({ state: "implementing" });
+    await wrapped(ctx);
+
+    expect(receivedSignal).toBeInstanceOf(AbortSignal);
+    expect(receivedSignal!.aborted).toBe(false);
+  });
+
+  it("aborts _abortSignal when timeout fires", async () => {
+    let receivedSignal: AbortSignal | undefined;
+    const inner: StateHandler = async (ctx) => {
+      receivedSignal = ctx._abortSignal;
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      return { nextState: "reviewing" as RunState, ctx };
+    };
+
+    const wrapped = withTimeout(inner, 30);
+    const ctx = makeCtx({ state: "implementing" });
+    const result = await wrapped(ctx);
+
+    expect(result.nextState).toBe("manual_handoff");
+    expect(receivedSignal).toBeInstanceOf(AbortSignal);
+    expect(receivedSignal!.aborted).toBe(true);
+  });
 });
 
 describe("runWorkflow with stateTimeouts", () => {

--- a/test/workflow/engine.test.ts
+++ b/test/workflow/engine.test.ts
@@ -480,4 +480,57 @@ describe("withTimeout", () => {
 
     expect(result.ctx.fixAttempts).toBe(2);
   });
+
+  it("clears timer when handler completes before timeout", async () => {
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+
+    const inner: StateHandler = async (ctx) => ({
+      nextState: "reviewing" as RunState,
+      ctx,
+    });
+
+    const wrapped = withTimeout(inner, 60000);
+    const ctx = makeCtx({ state: "implementing" });
+    await wrapped(ctx);
+
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+});
+
+describe("runWorkflow with stateTimeouts", () => {
+  it("applies timeout to handler when stateTimeouts is configured", async () => {
+    // Handler that takes 200ms but has a 50ms timeout
+    const slowHandler: StateHandler = async (ctx) => {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      return { nextState: "reviewing" as RunState, ctx };
+    };
+    const handlers: StateHandlerMap = {
+      implementing: slowHandler,
+    };
+    const persistence = makePersistence();
+    const ctx = makeCtx({
+      state: "implementing",
+      stateTimeouts: { implementing: 50 },
+    });
+
+    const result = await runWorkflow(ctx, handlers, persistence);
+
+    expect(result.state).toBe("manual_handoff");
+    expect(result._timedOutState).toBe("implementing");
+  });
+
+  it("does not apply timeout when stateTimeouts is not set for the state", async () => {
+    const handlers: StateHandlerMap = {
+      init: makeHandler("done"),
+    };
+    const persistence = makePersistence();
+    const ctx = makeCtx({
+      stateTimeouts: { implementing: 50 },
+    });
+
+    const result = await runWorkflow(ctx, handlers, persistence);
+
+    expect(result.state).toBe("done");
+  });
 });

--- a/test/workflow/engine.test.ts
+++ b/test/workflow/engine.test.ts
@@ -12,17 +12,23 @@ import type { Logger } from "../../src/util/logger.js";
 function makeCtx(overrides: Partial<RunContext> = {}): RunContext {
   return {
     runId: "test-run",
+    targetKind: "issue",
     issueNumber: 1,
     repo: "owner/repo",
     cwd: "/tmp/repo",
     state: "init",
     branch: "aidev/issue-1",
+    base: "main",
     maxFixAttempts: 3,
     fixAttempts: 0,
+    maxReviewRounds: 1,
+    reviewRound: 0,
     dryRun: false,
     autoMerge: false,
+    language: "ja",
     issueLabels: [],
     skipStates: [],
+    skipAuthorCheck: false,
     ...overrides,
   };
 }
@@ -191,6 +197,8 @@ describe("runWorkflow", () => {
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
+      setLogFile: vi.fn(),
+      flush: vi.fn(async () => {}),
     };
 
     await runWorkflow(ctx, handlers, persistence, { logger });
@@ -217,6 +225,8 @@ describe("runWorkflow", () => {
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
+      setLogFile: vi.fn(),
+      flush: vi.fn(async () => {}),
     };
 
     await runWorkflow(ctx, handlers, persistence, { logger });
@@ -304,6 +314,8 @@ describe("runWorkflow", () => {
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
+      setLogFile: vi.fn(),
+      flush: vi.fn(async () => {}),
     };
 
     await expect(
@@ -338,6 +350,8 @@ describe("runWorkflow", () => {
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
+      setLogFile: vi.fn(),
+      flush: vi.fn(async () => {}),
     };
 
     await expect(
@@ -718,5 +732,49 @@ describe("E2E: timeout → manual_handoff → resume → done", () => {
     expect(loaded!._timedOutState).toBe("reviewing");
     expect(loaded!.handoffReason).toContain("reviewing");
     expect(loaded!.handoffReason).toContain("timed out");
+  });
+});
+
+describe("runWorkflow persistence error handling", () => {
+  it("re-throws when persistence.save fails", async () => {
+    const saveError = new Error("disk full");
+    const handlers: StateHandlerMap = { init: makeHandler("done") };
+    const persistence: Persistence = {
+      save: vi.fn(async () => { throw saveError; }),
+      load: vi.fn(async () => null),
+    };
+    const ctx = makeCtx();
+
+    await expect(runWorkflow(ctx, handlers, persistence)).rejects.toBe(saveError);
+  });
+
+  it("logs error context when persistence.save fails", async () => {
+    const saveError = new Error("disk full");
+    const handlers: StateHandlerMap = { init: makeHandler("done") };
+    const persistence: Persistence = {
+      save: vi.fn(async () => { throw saveError; }),
+      load: vi.fn(async () => null),
+    };
+    const ctx = makeCtx();
+    const logger: Logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      setLogFile: vi.fn(),
+      flush: vi.fn(async () => {}),
+    };
+
+    await expect(
+      runWorkflow(ctx, handlers, persistence, { logger })
+    ).rejects.toBe(saveError);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("persist"),
+      expect.objectContaining({
+        state: "done",
+        runId: "test-run",
+      })
+    );
   });
 });

--- a/test/workflow/engine.test.ts
+++ b/test/workflow/engine.test.ts
@@ -481,6 +481,18 @@ describe("withTimeout", () => {
     expect(result.ctx.fixAttempts).toBe(2);
   });
 
+  it("propagates handler rejection instead of swallowing it", async () => {
+    const error = new Error("handler crashed");
+    const inner: StateHandler = async () => {
+      throw error;
+    };
+
+    const wrapped = withTimeout(inner, 5000);
+    const ctx = makeCtx({ state: "implementing" });
+
+    await expect(wrapped(ctx)).rejects.toBe(error);
+  });
+
   it("clears timer when handler completes before timeout", async () => {
     const clearSpy = vi.spyOn(globalThis, "clearTimeout");
 

--- a/test/workflow/states.test.ts
+++ b/test/workflow/states.test.ts
@@ -162,7 +162,7 @@ describe("init handler", () => {
     const handlers = createStateHandlers(deps);
     const ctx = makeCtx();
 
-    await expect(handlers.init!(ctx)).rejects.toThrow("not created by the authenticated user");
+    await expect(handlers.init!(ctx)).rejects.toThrow("not by the authenticated user");
   });
 
   it("allows issue when author matches authenticated user", async () => {

--- a/test/workflow/states.test.ts
+++ b/test/workflow/states.test.ts
@@ -162,7 +162,7 @@ describe("init handler", () => {
     const handlers = createStateHandlers(deps);
     const ctx = makeCtx();
 
-    await expect(handlers.init!(ctx)).rejects.toThrow("foreignuser");
+    await expect(handlers.init!(ctx)).rejects.toThrow("not created by the authenticated user");
   });
 
   it("allows issue when author matches authenticated user", async () => {

--- a/test/workflow/states.test.ts
+++ b/test/workflow/states.test.ts
@@ -1613,3 +1613,111 @@ describe("closing_issue handler", () => {
     expect(deps.github.closeIssue).not.toHaveBeenCalled();
   });
 });
+
+describe("abort signal in handlers", () => {
+  it("planning returns manual_handoff when signal already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const deps = makeDeps();
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({ state: "planning", _abortSignal: ac.signal });
+
+    const result = await handlers.planning!(ctx);
+
+    expect(result.nextState).toBe("manual_handoff");
+    expect(result.ctx.handoffReason).toContain("planning");
+  });
+
+  it("implementing returns manual_handoff when signal already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const deps = makeDeps();
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      state: "implementing",
+      plan: { summary: "test", steps: ["do it"], filesToTouch: [], tests: [], risks: [], acceptanceCriteria: [] },
+      _abortSignal: ac.signal,
+    });
+
+    const result = await handlers.implementing!(ctx);
+
+    expect(result.nextState).toBe("manual_handoff");
+    expect(result.ctx.handoffReason).toContain("implementing");
+  });
+
+  it("reviewing returns manual_handoff when signal already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const deps = makeDeps();
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      state: "reviewing",
+      prNumber: 42,
+      plan: { summary: "test", steps: ["do it"], filesToTouch: [], tests: [], risks: [], acceptanceCriteria: [] },
+      _abortSignal: ac.signal,
+    });
+
+    const result = await handlers.reviewing!(ctx);
+
+    expect(result.nextState).toBe("manual_handoff");
+    expect(result.ctx.handoffReason).toContain("reviewing");
+  });
+
+  it("fixing returns manual_handoff when signal already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const deps = makeDeps();
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      state: "fixing",
+      plan: { summary: "test", steps: ["do it"], filesToTouch: [], tests: [], risks: [], acceptanceCriteria: [] },
+      fixTrigger: "ci",
+      _abortSignal: ac.signal,
+    });
+
+    const result = await handlers.fixing!(ctx);
+
+    expect(result.nextState).toBe("manual_handoff");
+    expect(result.ctx.handoffReason).toContain("fixing");
+    // Should NOT have called git.addAll/commit/push
+    expect(deps.git.addAll).not.toHaveBeenCalled();
+  });
+
+  it("fixing aborts before git push when signal fires during agent run", async () => {
+    const ac = new AbortController();
+    const deps = makeDeps();
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      state: "fixing",
+      plan: { summary: "test", steps: ["do it"], filesToTouch: [], tests: [], risks: [], acceptanceCriteria: [] },
+      fixTrigger: "ci",
+      _abortSignal: ac.signal,
+    });
+
+    // Abort during agent execution (runFixer is mocked, so abort after it returns)
+    // The handler checks _abortSignal AFTER runFixer completes
+    ac.abort();
+
+    const result = await handlers.fixing!(ctx);
+
+    // Should transition to manual_handoff without git operations
+    expect(result.nextState).toBe("manual_handoff");
+    expect(deps.git.addAll).not.toHaveBeenCalled();
+    expect(deps.git.commit).not.toHaveBeenCalled();
+    expect(deps.git.push).not.toHaveBeenCalled();
+  });
+
+  it("watching_ci returns manual_handoff when signal already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const deps = makeDeps();
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({ state: "watching_ci", prNumber: 42, _abortSignal: ac.signal });
+
+    const result = await handlers.watching_ci!(ctx);
+
+    expect(result.nextState).toBe("manual_handoff");
+    // Should NOT have called getCiStatus since it checks signal first
+    expect(deps.github.getCiStatus).not.toHaveBeenCalled();
+  });
+});

--- a/test/workflow/states.test.ts
+++ b/test/workflow/states.test.ts
@@ -437,6 +437,56 @@ describe("init handler", () => {
     expect(result.ctx.base).toBe("cli-branch");
   });
 
+  it("propagates stateTimeouts from issue body config to ctx", async () => {
+    const deps = makeDeps({
+      github: {
+        getIssue: vi.fn(async () => ({
+          number: 1,
+          title: "Test",
+          body: "```aidev\nstateTimeouts:\n  implementing: 1800000\n  reviewing: 600000\n```",
+          labels: [],
+          author: "testuser",
+        })),
+      },
+    });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx();
+
+    const result = await handlers.init!(ctx);
+
+    expect(result.ctx.stateTimeouts).toEqual({
+      implementing: 1800000,
+      reviewing: 600000,
+    });
+  });
+
+  it("writes stateTimeouts back to issue body in resolved config", async () => {
+    const deps = makeDeps({
+      github: {
+        getIssue: vi.fn(async () => ({
+          number: 1,
+          title: "Test",
+          body: "```aidev\nstateTimeouts:\n  implementing: 1800000\n```",
+          labels: [],
+          author: "testuser",
+        })),
+      },
+    });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx();
+
+    await handlers.init!(ctx);
+
+    expect(deps.github.updateIssueBody).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("stateTimeouts:"),
+    );
+    expect(deps.github.updateIssueBody).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("implementing: 1800000"),
+    );
+  });
+
   it("writes resolved config back to issue body", async () => {
     const deps = makeDeps();
     const handlers = createStateHandlers(deps);


### PR DESCRIPTION
## Summary

Clean re-implementation of #72 on latest main, addressing all review feedback from both the original PR and 5 rounds of staff engineer review.

- Adds `manual_handoff` as a recoverable terminal state
- Implements `withTimeout()` wall-clock timeout wrapper for state handlers
- Adds `stateTimeouts` config (per-state timeout in ms) with 3-layer merge support
- Resume from `manual_handoff` restarts from `_timedOutState`
- Slack notifications show `:raised_hand:` icon for handoff
- Watch mode preserves worktree and logs resume command on `manual_handoff`

## Review feedback addressed

### Original PR #72 feedback

| Item | Status |
|------|--------|
| MUST FIX: `.entire/` dir in commits | Not included |
| MUST FIX: `withTimeout` cancellation | Logs warning on timeout |
| SHOULD FIX: Code duplication in timeout | Uses `Infinity` default — single path |
| SHOULD FIX: `stateTimeouts` key validation | Validates against `RunStateSchema` |
| SHOULD FIX: `_timedOutState` unsafe cast | Uses `RunStateSchema.safeParse()` |
| SHOULD FIX: Sync exec | No sync exec added |
| NIT: Scope creep | Only manual_handoff + timeouts |
| NIT: Format changes | None |
| NIT: Watch command | Handles `manual_handoff` with worktree preservation |
| CRITICAL: Rebase on latest main | Built from latest main (6e62c61) |

### Staff engineer review rounds (5 rounds)

| Round | Fixes |
|-------|-------|
| 0 | Wired `withTimeout` into `runWorkflow`, fixed timer leak, safeParse for `_timedOutState`, exclusive list/map in `flushCurrent`, `TerminalState` type |
| 1 | Handler rejection propagation in `withTimeout`, `stateTimeouts` propagation from config, unified `TERMINAL_STATES` constant |
| 2 | `serializeConfig` stateTimeouts support, round-trip test, `withTimeout` guards (<=0, non-finite) |
| 3 | Deterministic stateTimeouts sort, JSDoc update |
| 4 | Worktree preservation on `manual_handoff` (`keepWorktree` flag) |
| 5 | JSON output includes `worktreePath` for `manual_handoff` |
| Final | CLI integration tests for resume, watch mode guidance log, stateTimeouts propagation test |

## Changed files

- `src/types.ts` — `TERMINAL_STATES` const, `TerminalState` type, `manual_handoff` state, `handoffReason`, `_timedOutState`, `stateTimeouts`
- `src/workflow/engine.ts` — `withTimeout()` with timer cleanup and rejection propagation, terminal state set from `TERMINAL_STATES`
- `src/workflow/states.ts` — `stateTimeouts` propagation in `loadAndMergeConfig`, unified terminal states
- `src/adapters/slack.ts` — `:raised_hand:` icon, `TerminalState` type import
- `src/cli.ts` — Resume from handoff, `keepWorktree` flag, worktree preservation, JSON output with `worktreePath`, watch mode guidance log
- `src/config/issue-config.ts` — `stateTimeouts` parsing with key validation, exclusive list/map flush
- `src/config/merge-config.ts` — Deep merge for `stateTimeouts`
- `src/config/serialize-config.ts` — `stateTimeouts` serialization with alphabetical sort

## Test plan

- [x] 501/501 tests pass (33 test files)
- [x] `tsc --noEmit` passes with zero errors
- [x] `withTimeout` tests: timeout fires, handler completes, rejection propagation, edge cases (<=0, non-finite)
- [x] `runWorkflow` + `stateTimeouts` integration tests
- [x] CLI resume from `manual_handoff` tests (with/without `_timedOutState`)
- [x] Worktree preservation test on `manual_handoff` result
- [x] `stateTimeouts` propagation from issue body to ctx
- [x] `serializeConfig` stateTimeouts round-trip test
- [x] Slack formatting, config parsing, config merging tests

Supersedes #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)