### PR TITLE
feat: support per-step backend configuration for workflow steps (#105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ bun run aidev run --pr <number> --repo <owner/name> --cwd <path>
 | `--allow-foreign-issues` | 他ユーザーが作成した Issue の処理を許可 | `false` |
 | `--backend <name>` | 使用するバックエンドランナー | `claude-code` |
 | `--model <model>` | バックエンドで使用するモデル | — |
+| `--planning <backend>` | planning ステップで使用するバックエンド | `--backend` の値 |
+| `--implementing <backend>` | implementing ステップで使用するバックエンド | `--backend` の値 |
+| `--reviewing <backend>` | reviewing ステップで使用するバックエンド | `--backend` の値 |
+| `--fixing <backend>` | fixing ステップで使用するバックエンド | `--backend` の値 |
 
 `--issue` と `--pr` は排他的で、**どちらか一方を必ず指定**する。
 
@@ -93,6 +97,7 @@ maxFixAttempts: 5
 autoMerge: true
 base: release/1.3
 language: ja
+implementing: codex-sdk
 skip:
   - reviewing
   - documenter
@@ -109,6 +114,10 @@ skip:
 | `skip` | string[] | スキップする工程（下記参照） |
 | `backend` | string | 使用するバックエンドランナー |
 | `model` | string | バックエンドで使用するモデル |
+| `planning` | string | planning ステップで使用するバックエンド |
+| `implementing` | string | implementing ステップで使用するバックエンド |
+| `reviewing` | string | reviewing ステップで使用するバックエンド |
+| `fixing` | string | fixing ステップで使用するバックエンド |
 
 `skip` で指定可能な工程:
 
@@ -138,6 +147,17 @@ export AIDEV_MODEL=claude-sonnet-4-6
 | `codex-sdk` | OpenAI Codex SDK (`@openai/codex-sdk`) を使用 | 対応 |
 
 `codex-sdk` バックエンドは `OPENAI_API_KEY` 環境変数（または `apiKey` 設定）が必要。`codex-cli` バックエンドはローカルにインストールされた `codex` CLI を使用する。
+
+#### ステップ別バックエンド
+
+ワークフローの各ステップ（planning, implementing, reviewing, fixing）ごとに異なるバックエンドを指定できる。未指定のステップは `--backend` の値にフォールバックする。同じバックエンドが複数ステップで使われる場合はランナーインスタンスが共有される。
+
+```bash
+bun run aidev run --issue 42 --repo owner/name \
+  --backend claude-code \
+  --implementing codex-sdk \
+  --reviewing claude-code
+```
 
 ### `watch` — ラベル付き Issue を監視して自動処理
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { runDocumenter } from "./agents/documenter.js";
 import { createRunner } from "./agents/runner-factory.js";
 import { DEFAULT_BACKEND } from "./agents/backend-config.js";
 import type { BackendConfig } from "./agents/backend-config.js";
+import type { StepBackends } from "./types.js";
 import { createSlackNotifier, formatSlackMessage } from "./adapters/slack.js";
 import { loadRepoConfig } from "./config/repo-config.js";
 import { writeAidevYml } from "./config/init.js";
@@ -103,8 +104,6 @@ function createFilePersistence(baseDir: string): Persistence {
     },
   };
 }
-
-import type { StepBackends } from "./types.js";
 
 function buildStepBackends(opts: Record<string, unknown>): StepBackends | undefined {
   const steps: StepBackends = {};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -104,6 +104,16 @@ function createFilePersistence(baseDir: string): Persistence {
   };
 }
 
+import type { StepBackends } from "./types.js";
+
+function buildStepBackends(opts: Record<string, unknown>): StepBackends | undefined {
+  const steps: StepBackends = {};
+  for (const step of ["planning", "implementing", "reviewing", "fixing"] as const) {
+    if (typeof opts[step] === "string") steps[step] = opts[step];
+  }
+  return Object.keys(steps).length > 0 ? steps : undefined;
+}
+
 function resolveBackendConfig(opts: { backend?: string; model?: string }): BackendConfig {
   return {
     backend: opts.backend ?? process.env.AIDEV_BACKEND ?? DEFAULT_BACKEND,
@@ -136,7 +146,11 @@ export function createCli() {
     .option("--verbose", "Emit JSONL progress lines to stderr for external agent observability", false)
     .option("--backend <name>", "Backend runner to use", DEFAULT_BACKEND)
     .option("--model <model>", "Model to use with the backend")
-    .option("--language <lang>", "Output language (ja or en)", "ja");
+    .option("--language <lang>", "Output language (ja or en)", "ja")
+    .option("--planning <backend>", "Backend for the planning step")
+    .option("--implementing <backend>", "Backend for the implementing step")
+    .option("--reviewing <backend>", "Backend for the reviewing step")
+    .option("--fixing <backend>", "Backend for the fixing step");
 
   runCmd.action(async (opts) => {
       if (opts.claudePath) process.env.CLAUDE_EXECUTABLE = opts.claudePath;
@@ -244,6 +258,10 @@ export function createCli() {
           backend: "backend",
           model: "model",
           language: "language",
+          planning: "planning",
+          implementing: "implementing",
+          reviewing: "reviewing",
+          fixing: "fixing",
         };
         for (const [ctxKey, cliName] of Object.entries(flagMap)) {
           if (runCmd.getOptionValueSource(cliName) === "cli") {
@@ -272,6 +290,7 @@ export function createCli() {
           issueLabels: [],
           skipStates: [],
           skipAuthorCheck: opts.allowForeignIssues,
+          stepBackends: buildStepBackends(opts),
           _cliExplicit: cliExplicit.size > 0 ? cliExplicit : undefined,
         };
       }

--- a/src/config/issue-config.ts
+++ b/src/config/issue-config.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
-import { SkippableStateSchema, LanguageSchema } from "../types.js";
-import type { SkippableState, Language } from "../types.js";
+import { SkippableStateSchema, LanguageSchema, StepNameSchema } from "../types.js";
+import type { SkippableState, Language, StepBackends } from "../types.js";
 
-export type { SkippableState, Language } from "../types.js";
+export type { SkippableState, Language, StepBackends } from "../types.js";
 export { LanguageSchema } from "../types.js";
+
+const STEP_NAMES = StepNameSchema.options;
 
 const IssueConfigSchema = z
   .object({
@@ -16,6 +18,10 @@ const IssueConfigSchema = z
     backend: z.string().optional(),
     model: z.string().optional(),
     language: LanguageSchema.optional(),
+    planning: z.string().optional(),
+    implementing: z.string().optional(),
+    reviewing: z.string().optional(),
+    fixing: z.string().optional(),
   })
   .strict();
 
@@ -31,6 +37,10 @@ export interface ResolvedConfig {
   backend?: string;
   model?: string;
   language: Language;
+  planning?: string;
+  implementing?: string;
+  reviewing?: string;
+  fixing?: string;
 }
 
 /**
@@ -149,6 +159,12 @@ export function parseConfigBlock(block: string): Partial<IssueConfig> {
 
   if (typeof raw.language === "string" && LanguageSchema.safeParse(raw.language).success) {
     obj.language = raw.language;
+  }
+
+  for (const step of STEP_NAMES) {
+    if (typeof raw[step] === "string" && raw[step].length > 0) {
+      obj[step] = raw[step];
+    }
   }
 
   if (Array.isArray(raw.skip)) {

--- a/src/config/serialize-config.ts
+++ b/src/config/serialize-config.ts
@@ -17,6 +17,12 @@ export function serializeConfig(config: ResolvedConfig): string {
     lines.push(`model: ${config.model}`);
   }
 
+  for (const step of ["planning", "implementing", "reviewing", "fixing"] as const) {
+    if (config[step]) {
+      lines.push(`${step}: ${config[step]}`);
+    }
+  }
+
   if (config.skip.length > 0) {
     lines.push("skip:");
     for (const s of config.skip) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,16 @@
 import { z } from "zod";
 
+export const StepNameSchema = z.enum(["planning", "implementing", "reviewing", "fixing"]);
+export type StepName = z.infer<typeof StepNameSchema>;
+
+export const StepBackendsSchema = z.object({
+  planning: z.string().optional(),
+  implementing: z.string().optional(),
+  reviewing: z.string().optional(),
+  fixing: z.string().optional(),
+});
+export type StepBackends = z.infer<typeof StepBackendsSchema>;
+
 export const SkippableStateSchema = z.enum([
   "reviewing",
   "watching_ci",
@@ -89,6 +100,7 @@ export const RunContextSchema = z.object({
   review: ReviewSchema.optional(),
   fix: FixSchema.optional(),
   fixTrigger: z.enum(["ci", "review"]).optional(),
+  stepBackends: StepBackendsSchema.optional(),
 }).superRefine((ctx, issueCtx) => {
   if (ctx.targetKind === "issue" && ctx.issueNumber == null) {
     issueCtx.addIssue({

--- a/src/workflow/states.ts
+++ b/src/workflow/states.ts
@@ -1,5 +1,5 @@
 import type { AgentRunner, ProgressEvent } from "../agents/runner.js";
-import type { StateHandler, RunContext, RunState, Review, Language } from "../types.js";
+import type { StateHandler, RunContext, RunState, Review, Language, StepName } from "../types.js";
 import type { StateHandlerMap } from "./engine.js";
 import type { GitAdapter } from "../adapters/git.js";
 import type { GitHubAdapter } from "../adapters/github.js";
@@ -113,6 +113,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
   const { git, github, logger, runDocumenter, loadRepoConfig } = deps;
   const defaultRunner = deps.runner;
   const runnerByRunId = new Map<string, AgentRunner>();
+  const runnerCache = new Map<string, AgentRunner>();
 
   function transition(
     ctx: RunContext,
@@ -121,11 +122,20 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
   ) {
     if (terminalStates.has(nextState)) {
       runnerByRunId.delete(ctx.runId);
+      runnerCache.clear();
     }
     return { nextState, ctx: { ...ctx, ...patch, state: nextState } };
   }
 
-  function getRunner(ctx: RunContext): AgentRunner {
+  function getRunner(ctx: RunContext, step?: StepName): AgentRunner {
+    if (step && ctx.stepBackends?.[step]) {
+      const backendName = ctx.stepBackends[step]!;
+      const cached = runnerCache.get(backendName);
+      if (cached) return cached;
+      const runner = deps.resolveRunner({ backend: backendName });
+      runnerCache.set(backendName, runner);
+      return runner;
+    }
     return runnerByRunId.get(ctx.runId) ?? defaultRunner;
   }
 
@@ -159,6 +169,20 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
     if (merged.skip) patch.skipStates = merged.skip as SkippableState[];
     if (merged.language !== undefined) patch.language = merged.language;
 
+    // Merge step-specific backends
+    const stepBackendKeys = ["planning", "implementing", "reviewing", "fixing"] as const;
+    const mergedStepBackends = { ...(ctx.stepBackends ?? {}) };
+    let hasStepBackends = false;
+    for (const step of stepBackendKeys) {
+      if (merged[step]) {
+        mergedStepBackends[step] = merged[step];
+        hasStepBackends = true;
+      }
+    }
+    if (hasStepBackends || ctx.stepBackends) {
+      patch.stepBackends = mergedStepBackends;
+    }
+
     // Re-create runner if backend/model changed via config
     if (merged.backend || merged.model) {
       const resolved = deps.resolveRunner({
@@ -185,6 +209,10 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
       backend: merged.backend,
       model: merged.model,
       language: mergedCtx.language,
+      planning: mergedCtx.stepBackends?.planning,
+      implementing: mergedCtx.stepBackends?.implementing,
+      reviewing: mergedCtx.stepBackends?.reviewing,
+      fixing: mergedCtx.stepBackends?.fixing,
     };
     const configBlock = buildResolvedConfigBlock(resolvedConfig);
     const updatedBody = upsertAidevBlock(body, configBlock);
@@ -268,7 +296,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
         ? toPlanningTarget(await github.getPr(ctx.prNumber!))
         : await github.getIssue(ctx.issueNumber!);
     const planStart = performance.now();
-    const plan = await runPlanner({ issue: workItem, cwd: ctx.cwd, language: ctx.language }, logger, getRunner(ctx), deps.onProgress);
+    const plan = await runPlanner({ issue: workItem, cwd: ctx.cwd, language: ctx.language }, logger, getRunner(ctx, "planning"), deps.onProgress);
     const planElapsed = Math.round(performance.now() - planStart);
     logger.info("Plan created", { summary: plan.summary, agentElapsedMs: planElapsed });
 
@@ -299,7 +327,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
         cwd: ctx.cwd,
       },
       logger,
-      getRunner(ctx),
+      getRunner(ctx, "implementing"),
       deps.onProgress
     );
     const implElapsed = Math.round(performance.now() - implStart);
@@ -324,7 +352,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
     const review = await runReviewer(
       { plan: ctx.plan, diff, cwd: ctx.cwd, language: ctx.language },
       logger,
-      getRunner(ctx),
+      getRunner(ctx, "reviewing"),
       deps.onProgress,
       { reviewRound: currentRound, maxReviewRounds: maxRounds },
     );
@@ -448,7 +476,7 @@ export function createStateHandlers(deps: Deps): StateHandlerMap {
     const fix = await runFixer(
       fixerInput,
       logger,
-      getRunner(ctx),
+      getRunner(ctx, "fixing"),
       deps.onProgress
     );
     const fixElapsed = Math.round(performance.now() - fixStart);

--- a/test/config/issue-config.test.ts
+++ b/test/config/issue-config.test.ts
@@ -176,4 +176,29 @@ describe("parseIssueConfig", () => {
     expect(result.language).toBeUndefined();
     expect(result.maxFixAttempts).toBe(3);
   });
+
+  it("parses step-specific backend fields", () => {
+    const body = "```aidev\nplanning: codex-cli\nimplementing: claude-code\nreviewing: codex-cli\nfixing: claude-code\n```";
+    const result = parseIssueConfig(body);
+    expect(result.planning).toBe("codex-cli");
+    expect(result.implementing).toBe("claude-code");
+    expect(result.reviewing).toBe("codex-cli");
+    expect(result.fixing).toBe("claude-code");
+  });
+
+  it("parses partial step backend fields", () => {
+    const body = "```aidev\nplanning: codex-cli\n```";
+    const result = parseIssueConfig(body);
+    expect(result.planning).toBe("codex-cli");
+    expect(result.implementing).toBeUndefined();
+    expect(result.reviewing).toBeUndefined();
+    expect(result.fixing).toBeUndefined();
+  });
+
+  it("ignores empty step backend values", () => {
+    const body = "```aidev\nplanning:\nmaxFixAttempts: 3\n```";
+    const result = parseIssueConfig(body);
+    expect(result.planning).toBeUndefined();
+    expect(result.maxFixAttempts).toBe(3);
+  });
 });

--- a/test/config/merge-config.test.ts
+++ b/test/config/merge-config.test.ts
@@ -79,4 +79,25 @@ describe("mergeConfigs", () => {
     expect(result).not.toHaveProperty("backend");
     expect(result).not.toHaveProperty("model");
   });
+
+  it("merges step-specific backend fields", () => {
+    const repo: Partial<IssueConfig> = { planning: "codex-cli", implementing: "claude-code" };
+    const issue: Partial<IssueConfig> = { planning: "openai" };
+
+    const result = mergeConfigs(repo, issue, new Set());
+
+    expect(result.planning).toBe("openai");
+    expect(result.implementing).toBe("claude-code");
+  });
+
+  it("excludes step backends when cli-explicit", () => {
+    const repo: Partial<IssueConfig> = { planning: "codex-cli" };
+    const issue: Partial<IssueConfig> = { implementing: "openai" };
+    const cliExplicit = new Set(["planning", "implementing"]);
+
+    const result = mergeConfigs(repo, issue, cliExplicit);
+
+    expect(result).not.toHaveProperty("planning");
+    expect(result).not.toHaveProperty("implementing");
+  });
 });

--- a/test/config/serialize-config.test.ts
+++ b/test/config/serialize-config.test.ts
@@ -68,6 +68,44 @@ describe("serializeConfig", () => {
     expect(result).not.toContain("model");
   });
 
+  it("includes step-specific backends when present", () => {
+    const config: ResolvedConfig = {
+      maxFixAttempts: 3,
+      maxReviewRounds: 1,
+      autoMerge: false,
+      dryRun: false,
+      base: "main",
+      language: "ja",
+      skip: [],
+      planning: "codex-cli",
+      implementing: "claude-code",
+    };
+
+    const result = serializeConfig(config);
+    expect(result).toContain("planning: codex-cli");
+    expect(result).toContain("implementing: claude-code");
+    expect(result).not.toContain("reviewing:");
+    expect(result).not.toContain("fixing:");
+  });
+
+  it("omits step backends when undefined", () => {
+    const config: ResolvedConfig = {
+      maxFixAttempts: 3,
+      maxReviewRounds: 1,
+      autoMerge: false,
+      dryRun: false,
+      base: "main",
+      language: "ja",
+      skip: [],
+    };
+
+    const result = serializeConfig(config);
+    expect(result).not.toContain("planning");
+    expect(result).not.toContain("implementing");
+    expect(result).not.toContain("reviewing");
+    expect(result).not.toContain("fixing");
+  });
+
   it("omits skip line when skip is empty array", () => {
     const config: ResolvedConfig = {
       maxFixAttempts: 3,

--- a/test/workflow/states.test.ts
+++ b/test/workflow/states.test.ts
@@ -1563,3 +1563,115 @@ describe("closing_issue handler", () => {
     expect(deps.github.closeIssue).not.toHaveBeenCalled();
   });
 });
+
+describe("step-specific backends", () => {
+  it("uses step-specific backend for planning when configured", async () => {
+    const stepRunner = { run: vi.fn(async () => "") };
+    const deps = makeDeps();
+    (deps.resolveRunner as ReturnType<typeof vi.fn>).mockImplementation((config: { backend: string }) => {
+      if (config.backend === "codex-cli") return stepRunner;
+      return deps.runner;
+    });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      state: "planning",
+      stepBackends: { planning: "codex-cli" },
+    });
+
+    await handlers.planning!(ctx);
+
+    expect(deps.resolveRunner).toHaveBeenCalledWith({ backend: "codex-cli" });
+  });
+
+  it("falls back to default runner when step backend is not set", async () => {
+    const deps = makeDeps();
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      state: "planning",
+    });
+
+    await handlers.planning!(ctx);
+
+    expect(deps.resolveRunner).not.toHaveBeenCalled();
+  });
+
+  it("shares runner instance for same backend across steps", async () => {
+    const stepRunner = { run: vi.fn(async () => "") };
+    const deps = makeDeps();
+    (deps.resolveRunner as ReturnType<typeof vi.fn>).mockReturnValue(stepRunner);
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      state: "planning",
+      stepBackends: { planning: "codex-cli", reviewing: "codex-cli" },
+      plan: {
+        summary: "test",
+        steps: ["step1"],
+        filesToTouch: [],
+        tests: [],
+        risks: [],
+        acceptanceCriteria: [],
+      },
+      prNumber: 42,
+    });
+
+    await handlers.planning!(ctx);
+
+    // reviewing should reuse the cached runner
+    const reviewCtx = makeCtx({
+      state: "reviewing",
+      stepBackends: { planning: "codex-cli", reviewing: "codex-cli" },
+      plan: ctx.plan,
+      prNumber: 42,
+    });
+    await handlers.reviewing!(reviewCtx);
+
+    // resolveRunner should only be called once since both use "codex-cli"
+    expect(deps.resolveRunner).toHaveBeenCalledTimes(1);
+  });
+
+  it("merges step backends from issue body config into ctx", async () => {
+    const deps = makeDeps({
+      github: {
+        getIssue: vi.fn(async () => ({
+          number: 1,
+          title: "Test",
+          body: "```aidev\nplanning: codex-cli\nimplementing: openai\n```",
+          labels: [],
+          author: "testuser",
+        })),
+      },
+    });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx();
+
+    const result = await handlers.init!(ctx);
+
+    expect(result.ctx.stepBackends).toEqual({
+      planning: "codex-cli",
+      implementing: "openai",
+    });
+  });
+
+  it("CLI step backends take precedence over issue body", async () => {
+    const deps = makeDeps({
+      github: {
+        getIssue: vi.fn(async () => ({
+          number: 1,
+          title: "Test",
+          body: "```aidev\nplanning: from-issue\n```",
+          labels: [],
+          author: "testuser",
+        })),
+      },
+    });
+    const handlers = createStateHandlers(deps);
+    const ctx = makeCtx({
+      stepBackends: { planning: "from-cli" },
+      _cliExplicit: new Set(["planning"]),
+    });
+
+    const result = await handlers.init!(ctx);
+
+    expect(result.ctx.stepBackends?.planning).toBe("from-cli");
+  });
+});


### PR DESCRIPTION
## 概要
ワークフローの各ステップ（planning, implementing, reviewing, fixing）ごとに異なるバックエンド/モデルを指定できるようにする機能を追加。

## 変更内容
- `StepBackends` 型と `StepName` 型を `src/types.ts` に追加
- `IssueConfigSchema` と `ResolvedConfig` にステップごとのバックエンドフィールド（planning, implementing, reviewing, fixing）を追加
- `parseConfigBlock` でステップごとのバックエンドをパース
- `serializeConfig` でステップごとのバックエンドをシリアライズ
- CLI に `--planning`, `--implementing`, `--reviewing`, `--fixing` フラグを追加
- `getRunner(ctx, step?)` に変更し、ステップ名に対応するバックエンドが設定されていればそのランナーを返す
- 同一バックエンドの場合はランナーインスタンスを共有する `runnerCache` を実装
- `loadAndMergeConfig` でステップごとのバックエンド設定を `RunContext.stepBackends` にマージ
- 各ステートハンドラー（planning, implementing, reviewing, fixing）でステップ名を `getRunner` に渡すよう変更

## テスト
- [x] 既存テストがパスすることを確認（全470テスト GREEN）
- [x] ステップごとのバックエンドパーステスト追加
- [x] ステップごとのバックエンドマージテスト追加
- [x] ステップごとのバックエンドシリアライズテスト追加
- [x] getRunner のステップ別解決テスト追加
- [x] ランナーインスタンス共有テスト追加
- [x] CLI > issue body 優先順位テスト追加

## 関連 Issue
closes #105